### PR TITLE
docs(linkedin): Removed `get_company_info` and `get_user_posts` from docs

### DIFF
--- a/docs/documentation/mcp-server/linkedin.mdx
+++ b/docs/documentation/mcp-server/linkedin.mdx
@@ -189,8 +189,6 @@ You can also specify scope and redirect_url in the authUrl, and we also support 
 |----------------------------------------|---------------------------------------------------------------------------------------|
 | get_profile_info                       | Retrieve LinkedIn profile information (current user or specified person)              |
 | create_post                            | Create a text/article post on LinkedIn with customizable visibility                   |
-| get_user_posts                         | Retrieve recent posts from a user's profile                                           |
-| get_company_info                       | Retrieve information about a LinkedIn company                                         |
 </Accordion>
 
 <Note>For more details about tool input schema, use the [list_tool](https://docs.klavis.ai/api-reference/mcp-server/list-tools) API.</Note>


### PR DESCRIPTION
## Description
Removed two non-functional tools from docs.

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
Related to #186 

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New MCP feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
<!-- Describe how you have tested these changes. -->

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 