### PR TITLE
feat(linkedin): Adds 4 new tool in Linkedin MCP Server

### DIFF
--- a/docs/documentation/mcp-server/linkedin.mdx
+++ b/docs/documentation/mcp-server/linkedin.mdx
@@ -188,7 +188,11 @@ You can also specify scope and redirect_url in the authUrl, and we also support 
 | Tool Name                              | Description                                                                           |
 |----------------------------------------|---------------------------------------------------------------------------------------|
 | linkedin_get_profile_info              | Retrieve LinkedIn profile information (current user or specified person)              |
+| linkedin_get_profile_picture           | Retrieve LinkedIn profile picture (current user or specified person)                  |
 | linkedin_create_post                   | Create a text/article post on LinkedIn with customizable visibility                   |
+| linkedin_create_hashtag_post           | Create a LinkedIn post with formatted hashtags                                        |
+| linkedin_create_url_share              | Create a LinkedIn post that shares a URL with metadata preview                        |
+| linkedin_format_rich_post              | Format rich text for LinkedIn posts with various formatting options                   |
 </Accordion>
 
 <Note>For more details about tool input schema, use the [list_tool](https://docs.klavis.ai/api-reference/mcp-server/list-tools) API.</Note>

--- a/mcp_servers/linkedin/tools/__init__.py
+++ b/mcp_servers/linkedin/tools/__init__.py
@@ -1,13 +1,17 @@
-from .auth import get_profile_info
-from .posts import create_post
+from .auth import get_profile_info, get_profile_picture
+from .posts import create_post, create_hashtag_post, format_rich_post, create_url_share
 from .base import linkedin_token_context
 
 __all__ = [
     # Auth/Profile
     "get_profile_info",
+    "get_profile_picture",
     
     # Posts
     "create_post",
+    "create_hashtag_post",
+    "format_rich_post",
+    "create_url_share",
     
     # Base
     "linkedin_token_context",

--- a/mcp_servers/linkedin/tools/auth.py
+++ b/mcp_servers/linkedin/tools/auth.py
@@ -33,3 +33,28 @@ async def get_profile_info(person_id: Optional[str] = None) -> Dict[str, Any]:
     except Exception as e:
         logger.exception(f"Error executing tool get_profile_info: {e}")
         raise e
+
+async def get_profile_picture(person_id: Optional[str] = None) -> Dict[str, Any]:
+    """Get LinkedIn profile picture URL. If person_id is None, gets current user's profile picture."""
+    logger.info(f"Executing tool: get_profile_picture with person_id: {person_id}")
+    try:
+        if person_id:
+            return {"error": "Getting other users' profile pictures requires elevated LinkedIn API permissions"}
+        
+        # Get current user's profile info which includes picture
+        profile_data = await make_linkedin_request("GET", "/userinfo")
+        
+        result = {
+            "id": profile_data.get("sub"),
+            "name": profile_data.get("name"),
+            "profile_picture_url": profile_data.get("picture"),
+            "has_picture": bool(profile_data.get("picture"))
+        }
+        
+        if not result["profile_picture_url"]:
+            result["note"] = "No profile picture found or user hasn't made it publicly accessible"
+            
+        return result
+    except Exception as e:
+        logger.exception(f"Error executing tool get_profile_picture: {e}")
+        raise e

--- a/mcp_servers/linkedin/tools/posts.py
+++ b/mcp_servers/linkedin/tools/posts.py
@@ -6,6 +6,121 @@ from .base import make_linkedin_request
 # Configure logging
 logger = logging.getLogger(__name__)
 
+def _format_hashtags(hashtags: List[str]) -> str:
+    """Format hashtags for LinkedIn posts"""
+    formatted = []
+    for tag in hashtags:
+        # Remove # if already present and add it back
+        clean_tag = tag.strip().lstrip('#')
+        if clean_tag:  # Only add non-empty tags
+            formatted.append(f"#{clean_tag}")
+    return " ".join(formatted)
+
+def format_rich_post(
+    text: str,
+    bold_text: Optional[List[str]] = None,
+    italic_text: Optional[List[str]] = None,
+    bullet_points: Optional[List[str]] = None,
+    numbered_list: Optional[List[str]] = None,
+    hashtags: Optional[List[str]] = None,
+    mentions: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """
+    Format rich text for LinkedIn posts with various formatting options.
+    This is a utility function that doesn't make API calls.
+    """
+    logger.info("Executing tool: format_rich_post")
+    try:
+        formatted_text = text
+        
+        # Apply bold formatting (LinkedIn uses **text** for bold)
+        if bold_text:
+            for bold in bold_text:
+                if bold in formatted_text:
+                    formatted_text = formatted_text.replace(bold, f"**{bold}**")
+        
+        # Apply italic formatting (LinkedIn uses *text* for italic)
+        if italic_text:
+            for italic in italic_text:
+                if italic in formatted_text:
+                    formatted_text = formatted_text.replace(italic, f"*{italic}*")
+        
+        # Add bullet points
+        if bullet_points:
+            bullet_section = "\n\n" + "\n".join([f"• {point}" for point in bullet_points])
+            formatted_text += bullet_section
+        
+        # Add numbered list
+        if numbered_list:
+            numbered_section = "\n\n" + "\n".join([f"{i+1}. {item}" for i, item in enumerate(numbered_list)])
+            formatted_text += numbered_section
+        
+        # Add mentions (LinkedIn uses @mention format)
+        if mentions:
+            mention_section = "\n\n" + " ".join([f"@{mention}" for mention in mentions])
+            formatted_text += mention_section
+        
+        # Add hashtags
+        if hashtags:
+            hashtag_section = "\n\n" + _format_hashtags(hashtags)
+            formatted_text += hashtag_section
+        
+        result = {
+            "original_text": text,
+            "formatted_text": formatted_text,
+            "formatting_applied": {
+                "bold_count": len(bold_text) if bold_text else 0,
+                "italic_count": len(italic_text) if italic_text else 0,
+                "bullet_points": len(bullet_points) if bullet_points else 0,
+                "numbered_items": len(numbered_list) if numbered_list else 0,
+                "hashtags": len(hashtags) if hashtags else 0,
+                "mentions": len(mentions) if mentions else 0
+            },
+            "character_count": len(formatted_text),
+            "note": "This is formatted text ready for posting. Use linkedin_create_post to publish."
+        }
+        
+        return result
+        
+    except Exception as e:
+        logger.exception(f"Error executing tool format_rich_post: {e}")
+        return {
+            "error": "Rich text formatting failed",
+            "original_text": text,
+            "exception": str(e)
+        }
+
+async def create_hashtag_post(text: str, hashtags: List[str], title: Optional[str] = None, visibility: str = "PUBLIC") -> Dict[str, Any]:
+    """Create a LinkedIn post with formatted hashtags"""
+    logger.info(f"Executing tool: create_hashtag_post with {len(hashtags)} hashtags")
+    try:
+        # Format hashtags
+        formatted_hashtags = _format_hashtags(hashtags)
+        
+        # Combine text with hashtags
+        if formatted_hashtags:
+            full_text = f"{text}\n\n{formatted_hashtags}"
+        else:
+            full_text = text
+        
+        # Use the existing create_post function
+        result = await create_post(full_text, title, visibility)
+        
+        # Add hashtag info to result
+        if "error" not in result:
+            result["hashtags_used"] = formatted_hashtags
+            result["hashtag_count"] = len([h for h in hashtags if h.strip()])
+            
+        return result
+    except Exception as e:
+        logger.exception(f"Error executing tool create_hashtag_post: {e}")
+        return {
+            "error": "Hashtag post creation failed",
+            "text": text,
+            "hashtags": hashtags,
+            "exception": str(e)
+        }
+
 async def create_post(text: str, title: Optional[str] = None, visibility: str = "PUBLIC") -> Dict[str, Any]:
     """Create a post on LinkedIn with optional title for article-style posts."""
     tool_name = "create_article_post" if title else "create_text_post"
@@ -62,5 +177,75 @@ async def create_post(text: str, title: Optional[str] = None, visibility: str = 
             error_result["note"] = "Will attempt to create as formatted text post"
         
         return error_result
+
+async def create_url_share(url: str, text: str, title: Optional[str] = None, description: Optional[str] = None, visibility: str = "PUBLIC") -> Dict[str, Any]:
+    """Create a LinkedIn post that shares a URL with metadata preview"""
+    logger.info(f"Executing tool: create_url_share with URL: {url}")
+    try:
+        profile = await make_linkedin_request("GET", "/userinfo")
+        person_id = profile.get('sub')
+        
+        # Format content with title if provided
+        content = f"{title}\n\n{text}" if title else text
+        
+        endpoint = "/ugcPosts"
+        payload = {
+            "author": f"urn:li:person:{person_id}",
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    "shareCommentary": {
+                        "text": content
+                    },
+                    "shareMediaCategory": "ARTICLE",
+                    "media": [
+                        {
+                            "status": "READY",
+                            "description": {
+                                "text": description or "Shared link"
+                            },
+                            "originalUrl": url,
+                            "title": {
+                                "text": title or "Shared Content"
+                            }
+                        }
+                    ]
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": visibility
+            }
+        }
+        
+        post_data = await make_linkedin_request("POST", endpoint, json_data=payload)
+        result = {
+            "id": post_data.get("id"),
+            "created": post_data.get("created"),
+            "lastModified": post_data.get("lastModified"),
+            "lifecycleState": post_data.get("lifecycleState"),
+            "shared_url": url,
+            "url_title": title or "Shared Content",
+            "url_description": description or "Shared link"
+        }
+        
+        return result
+    except Exception as e:
+        logger.exception(f"Error executing tool create_url_share: {e}")
+        error_result = {
+            "error": "URL share creation failed - likely due to insufficient permissions or invalid URL",
+            "text": text,
+            "url": url,
+            "note": "Requires 'w_member_social' scope and valid URL format",
+            "exception": str(e)
+        }
+        
+        if title:
+            error_result["title"] = title
+        if description:
+            error_result["description"] = description
+            
+        return error_result
+
+
 
 


### PR DESCRIPTION
## Description
Added `get_profile_picture`, `create_hashtag_post`, `create_url_share`, and `format_rich_post` to LinkedIn mcp server.

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
Related to #165 

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New MCP feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
Tested with Claude and verified on LinkedIn as changes reflected perfectly.

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 