### PR TITLE
Add Full Spotify Integration to Shadow Listener MCP

### DIFF
--- a/mcp_servers/spotify/.env.example
+++ b/mcp_servers/spotify/.env.example
@@ -1,0 +1,8 @@
+# Spotify API Credentials
+# Create an app at https://developer.spotify.com/dashboard/applications
+SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token_here
+
+# Optional: Override default bearer token for MCP server auth
+MCP_BEARER_TOKEN=shadow-spotify-token

--- a/mcp_servers/spotify/README.md
+++ b/mcp_servers/spotify/README.md
@@ -1,0 +1,117 @@
+# 🎧 Spotify Shadow Listener MCP
+
+A FastMCP-based AI agent server that analyzes your Spotify listening history in a playful and insightful way.  
+It reveals your **listener identity**, analyzes your **taste shifts**, and even **predicts future music trends**—all without requiring full Spotify Premium access.
+
+---
+
+## ✨ Features
+
+- 🔄 **Listening Shift Analyzer** – Track how your musical vibe has evolved across time periods.
+- 🧠 **Listener Identity Tool** – Get your subculture persona and top genres.
+- 🔮 **Future Taste Predictor** – Forecast where your music energy is heading.
+- 🧭 **Smart Track Search** – Use GPT to help you search tracks via mood or situation.
+- 🗂 **Your Playlists Explorer** – Get all your playlists and dig into what’s inside.
+- 🧱 **Playlist Builder** – Create and add tracks to Spotify playlists using natural queries.
+- 📊 **Top Artists and Tracks** – Check out your most listened artists and songs over time.
+- 🧪 **Track Audio Features** – Dive into technical traits like valence, danceability, and more.
+- 🧠 **AI-Powered Recommendations** – Get music suggestions using Spotify's recommendation engine.
+- ▶️ **Now Playing Viewer** – See your currently playing track.
+- ❤️ **Artist Follow/Unfollow** – Manage your followed artists.
+- 🧹 **Playlist Cleanup Tools** – Remove tracks or delete entire playlists.
+
+---
+
+## 🛠 Setup
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/your-username/spotify-shadow-listener-mcp.git
+cd spotify-shadow-listener-mcp
+```
+
+### 2. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Create a `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Then fill in the `.env` file with your Spotify credentials:
+
+- Create an app at [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/applications)
+- Use the **Authorization Code Flow** to generate a refresh token.
+
+### 4. Run the MCP server
+
+```bash
+python spotify_shadow_listener_mcp.py
+```
+
+By default, it runs at `http://localhost:9090`.
+
+---
+
+## 🔐 Authentication
+
+This MCP server uses a simple Bearer Token for authorization.
+By default, it expects:
+
+```http
+Authorization: Bearer shadow-spotify-token
+```
+
+You can override this via the `.env` file:
+
+```env
+MCP_BEARER_TOKEN=your_custom_token
+```
+
+---
+
+## 🧪 Example Tools
+
+| Tool                      | Description                                                              |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `analyze_listening_shift` | Compares your top tracks' valence between two time ranges.               |
+| `get_listener_identity`   | Generates a fun listener persona based on your genre and mood profile.   |
+| `predict_future_taste`    | Projects your energy trend using recent vs long-term listening patterns. |
+| `search_tracks`           | Search Spotify using mood or artist/style descriptors.                   |
+| `get_user_playlists`      | Lists all your Spotify playlists.                                        |
+| `get_playlist_tracks`     | Shows what's inside a selected playlist.                                 |
+| `create_playlist`         | Creates a new playlist in your account.                                  |
+| `add_tracks_to_playlist`  | Adds specific tracks into one of your playlists.                         |
+| `get_top_artists`         | View your most-listened-to artists.                                     |
+| `get_top_tracks`          | View your most-played songs.                                            |
+| `get_audio_features`      | Retrieve technical stats for tracks.                                    |
+| `get_recommendations`     | Use Spotify's AI to get similar song suggestions.                       |
+| `get_currently_playing`   | See what you're listening to right now.                                |
+| `follow_artist`           | Follow a specific artist.                                               |
+| `unfollow_artist`         | Unfollow a specific artist.                                             |
+| `remove_tracks_from_playlist` | Remove tracks from a playlist.                                   |
+| `delete_playlist`         | Delete a playlist from your library.                                    |
+
+---
+
+## 📦 Built With
+
+- 🧠 [FastMCP](https://github.com/fixie-ai/fastmcp)
+- 🎧 [Spotify Web API](https://developer.spotify.com/documentation/web-api/)
+- 🔒 Bearer token authentication
+
+---
+
+## 📝 License
+
+MIT License
+
+---
+
+Built for fun and insight by music lovers ❤️🎶  
+*Not affiliated with Spotify.*

--- a/mcp_servers/spotify/main.py
+++ b/mcp_servers/spotify/main.py
@@ -1,0 +1,243 @@
+import os
+import json
+import asyncio
+import time
+import random
+import httpx
+
+from typing import Annotated, Dict, Any, List
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.bearer import BearerAuthProvider, RSAKeyPair
+from mcp import ErrorData, McpError
+from mcp.server.auth.provider import AccessToken
+from mcp.types import INTERNAL_ERROR, TextContent
+from pydantic import BaseModel, Field
+
+# ==== Load environment ==== 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+# ==== Configuration ==== 
+SPOTIFY_CLIENT_ID     = os.getenv("SPOTIFY_CLIENT_ID")
+SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
+REFRESH_TOKEN         = os.getenv("SPOTIFY_REFRESH_TOKEN")
+TOKEN                 = os.getenv("MCP_BEARER_TOKEN", "shadow-spotify-token")
+
+# ==== Auth Provider ==== 
+class SimpleBearerAuthProvider(BearerAuthProvider):
+    def __init__(self, token: str):
+        k = RSAKeyPair.generate()
+        super().__init__(public_key=k.public_key, jwks_uri=None, issuer=None, audience=None)
+        self.token = token
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        if token == self.token:
+            return AccessToken(token=token, client_id="shadow-listener", scopes=[], expires_at=None)
+        return None
+
+# ==== Spotify API Helper ==== 
+class SpotifyAPI:
+    TOKEN_URL = "https://accounts.spotify.com/api/token"
+    API_BASE  = "https://api.spotify.com/v1"
+    _access_token: str = ""
+    _expires_at: float  = 0.0
+
+    @classmethod
+    async def ensure_token(cls) -> str:
+        if time.time() < cls._expires_at - 60:
+            return cls._access_token
+        data = {
+            "grant_type":    "refresh_token",
+            "refresh_token": REFRESH_TOKEN,
+            "client_id":     SPOTIFY_CLIENT_ID,
+            "client_secret": SPOTIFY_CLIENT_SECRET,
+        }
+        async with httpx.AsyncClient() as client:
+            r = await client.post(cls.TOKEN_URL, data=data)
+            if r.status_code != 200:
+                raise McpError(ErrorData(code=INTERNAL_ERROR, message="Spotify auth failed"))
+            resp = r.json()
+            cls._access_token = resp["access_token"]
+            cls._expires_at   = time.time() + resp.get("expires_in", 3600)
+            return cls._access_token
+
+    @classmethod
+    async def get(cls, path: str, params: dict = None) -> Any:
+        token = await cls.ensure_token()
+        url = f"{cls.API_BASE}/{path}"
+        headers = {"Authorization": f"Bearer {token}"}
+        async with httpx.AsyncClient() as client:
+            r = await client.get(url, headers=headers, params=params)
+            if r.status_code >= 400:
+                raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Spotify GET {path} failed"))
+            return r.json()
+
+    @classmethod
+    async def post(cls, path: str, json_body: dict) -> Any:
+        token = await cls.ensure_token()
+        url = f"{cls.API_BASE}/{path}"
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        async with httpx.AsyncClient() as client:
+            r = await client.post(url, headers=headers, json=json_body)
+            if r.status_code >= 400:
+                raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Spotify POST {path} failed"))
+            return r.json()
+
+# ==== Tool Metadata ==== 
+class RichToolDescription(BaseModel):
+    description: str
+    use_when:    str
+    side_effects: str | None
+
+# ==== Server Init ==== 
+app = FastMCP("ShadowFM Spotify Companion", auth=SimpleBearerAuthProvider(TOKEN))
+
+def tool_desc(desc, use, side=None):
+    return RichToolDescription(description=desc, use_when=use, side_effects=side).model_dump_json()
+
+# === Insight Tools ===
+@app.tool(description=tool_desc("Analyze your listening shift between two periods.",
+                            "Track how your musical vibe changes.",
+                            "Fetches valence diff."))
+async def analyze_listening_shift(
+    start_range: Annotated[str, Field(description="short_term|medium_term|long_term")],
+    end_range:   Annotated[str, Field(description="short_term|medium_term|long_term")]
+) -> List[TextContent]:
+    before = await SpotifyAPI.get("me/top/tracks", {"time_range": start_range, "limit": 20})
+    after  = await SpotifyAPI.get("me/top/tracks", {"time_range": end_range,   "limit": 20})
+    bf = await SpotifyAPI.get("audio-features", {"ids": ",".join(t["id"] for t in before.get("items", []))})
+    af = await SpotifyAPI.get("audio-features", {"ids": ",".join(t["id"] for t in after.get("items", []))})
+    avg_b = sum(f.get("valence",0) for f in bf.get("audio_features", [])) / len(bf.get("audio_features", []))
+    avg_a = sum(f.get("valence",0) for f in af.get("audio_features", [])) / len(af.get("audio_features", []))
+    shift = avg_a - avg_b
+    vibe  = "upbeat" if shift>0.1 else "mellow" if shift<-0.1 else "stable"
+    return [TextContent(type="text", text=json.dumps({"shift": round(shift,2), "vibe": vibe}, indent=2))]
+
+@app.tool(description=tool_desc("Get your listener identity and subculture match.",
+                            "Identify your music persona.",
+                            "Aggregates top genres."))
+async def get_listener_identity() -> List[TextContent]:
+    data = await SpotifyAPI.get("me/top/tracks", {"time_range": "medium_term", "limit": 30})
+    counts: Dict[str,int] = {}
+    for t in data.get("items", []):
+        for a_ in t.get("artists", []):
+            gen = (await SpotifyAPI.get(f"artists/{a_["id"]}")).get("genres", [])
+            for g in gen:
+                counts[g] = counts.get(g,0) + 1
+    top5 = sorted(counts.items(), key=lambda x: x[1], reverse=True)[:5]
+    persona_map = {"pop":"Pop Enthusiast","rock":"Rock Rebel","jazz":"Jazz Aficionado"}
+    persona = persona_map.get(top5[0][0], "Eclectic Nomad")
+    return [TextContent(type="json", text=json.dumps({"persona": persona, "top_genres": top5}, indent=2))]
+
+@app.tool(description=tool_desc("Predict your future listening based on trend.",
+                            "Forecast your energy trend.",
+                            None))
+async def predict_future_taste() -> List[TextContent]:
+    short = await SpotifyAPI.get("me/top/tracks", {"time_range":"short_term","limit":10})
+    long  = await SpotifyAPI.get("me/top/tracks", {"time_range":"long_term","limit":10})
+    s_ids = [t["id"] for t in short.get("items",[])]
+    l_ids = [t["id"] for t in long.get("items",[])]
+    sf = await SpotifyAPI.get("audio-features", {"ids": ",".join(s_ids)})
+    lf = await SpotifyAPI.get("audio-features", {"ids": ",".join(l_ids)})
+    avg_s = sum(f.get("energy",0) for f in sf.get("audio_features",[])) / len(sf.get("audio_features",[]))
+    avg_l = sum(f.get("energy",0) for f in lf.get("audio_features",[])) / len(lf.get("audio_features",[]))
+    delta = avg_s - avg_l
+    forecast = "hyping up" if delta>0.1 else "winding down" if delta<-0.1 else "steady"
+    return [TextContent(type="text", text=json.dumps({"energy_trend": forecast}, indent=2))]
+
+# === Core Spotify Features ===
+@app.tool(description=tool_desc("Search tracks by keyword.", "Find tracks matching query.", None))
+async def search_tracks(q: Annotated[str,Field(description="Query text")], limit:Annotated[int,Field(default=10)]) -> List[TextContent]:
+    data = await SpotifyAPI.get("search", {"q": q, "type": "track", "limit": limit})
+    return [TextContent(type="json", text=json.dumps(data.get("tracks",{}), indent=2))]
+
+@app.tool(description=tool_desc("Get your playlists.", "List user playlists.", None))
+async def get_user_playlists(limit:Annotated[int,Field(default=20)]) -> List[TextContent]:
+    data = await SpotifyAPI.get("me/playlists",{"limit": limit})
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+@app.tool(description=tool_desc("Get playlist tracks.", "Fetch playlist items.", None))
+async def get_playlist_tracks(playlist_id:Annotated[str,Field(description="Playlist ID")], limit:Annotated[int,Field(default=20)]) -> List[TextContent]:
+    data = await SpotifyAPI.get(f"playlists/{playlist_id}/tracks",{"limit":limit})
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+@app.tool(description=tool_desc("Create playlist.", "Create new playlist.", None))
+async def create_playlist(name:Annotated[str,Field(description="Name")], description:Annotated[str,Field(default="")]) -> List[TextContent]:
+    user = await SpotifyAPI.get("me")
+    body = {"name": name, "description": description, "public": False}
+    data = await SpotifyAPI.post(f"users/{user['id']}/playlists", body)
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+@app.tool(description=tool_desc("Add tracks to playlist.", "Add URIs.", None))
+async def add_tracks_to_playlist(playlist_id:Annotated[str,Field(description="Playlist ID")], uris:Annotated[List[str],Field(description="Track URIs")]) -> List[TextContent]:
+    data = await SpotifyAPI.post(f"playlists/{playlist_id}/tracks",{"uris": uris})
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+# === Additional Spotify Endpoints ===
+@app.tool(description=tool_desc("Get top artists.", "View user top artists.", None))
+async def get_top_artists(time_range:Annotated[str,Field(description="short_term|medium_term|long_term")], limit:Annotated[int,Field(default=10)]) -> List[TextContent]:
+    data = await SpotifyAPI.get("me/top/artists", {"time_range": time_range, "limit": limit})
+    return [TextContent(type="json", text=json.dumps(data.get("items",[]), indent=2))]
+
+@app.tool(description=tool_desc("Get top tracks.", "View user top tracks.", None))
+async def get_top_tracks(time_range:Annotated[str,Field(description="short_term|medium_term|long_term")], limit:Annotated[int,Field(default=10)]) -> List[TextContent]:
+    data = await SpotifyAPI.get("me/top/tracks", {"time_range": time_range, "limit": limit})
+    return [TextContent(type="json", text=json.dumps(data.get("items",[]), indent=2))]
+
+@app.tool(description=tool_desc("Get recommendations.", "Get track recommendations.", None))
+async def get_recommendations(seed_artists:Annotated[List[str],Field(description="Artist IDs")]=[], seed_tracks:Annotated[List[str],Field(description="Track IDs")]=[], limit:Annotated[int,Field(default=10)]) -> List[TextContent]:
+    params = {"limit": limit}
+    if seed_artists: params["seed_artists"] = ",".join(seed_artists)
+    if seed_tracks:  params["seed_tracks"]  = ",".join(seed_tracks)
+    data = await SpotifyAPI.get("recommendations", params)
+    return [TextContent(type="json", text=json.dumps(data.get("tracks",[]), indent=2))]
+
+@app.tool(description=tool_desc("Get audio features.", "Retrieve audio features for tracks.", None))
+async def get_audio_features(track_ids:Annotated[List[str],Field(description="Track IDs")]) -> List[TextContent]:
+    data = await SpotifyAPI.get("audio-features", {"ids": ",".join(track_ids)})
+    return [TextContent(type="json", text=json.dumps(data.get("audio_features",[]), indent=2))]
+
+@app.tool(description=tool_desc("Currently playing.", "Get currently playing track.", None))
+async def get_currently_playing() -> List[TextContent]:
+    data = await SpotifyAPI.get("me/player/currently-playing")
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+@app.tool(description=tool_desc("Control playback.", "Pause, play, or skip tracks.", None))
+async def control_playback(action:Annotated[str,Field(description="play|pause|next|previous")]) -> List[TextContent]:
+    mapping = {"play": "play", "pause": "pause", "next": "next", "previous": "previous"}
+    path = f"me/player/{mapping.get(action, 'play')}"
+    await SpotifyAPI.post(path, {})
+    return [TextContent(type="text", text=f"Playback {action} executed.")]  
+
+@app.tool(description=tool_desc("Follow artist.", "Follow a specific artist.", None))
+async def follow_artist(artist_id:Annotated[str,Field(description="Artist ID")]) -> List[TextContent]:
+    await SpotifyAPI.put := SpotifyAPI.post(f"me/following?type=artist&ids={artist_id}", {})
+    return [TextContent(type="text", text=f"Now following artist {artist_id}.")]
+
+@app.tool(description=tool_desc("Unfollow artist.", "Unfollow a specific artist.", None))
+async def unfollow_artist(artist_id:Annotated[str,Field(description="Artist ID")]) -> List[TextContent]:
+    await SpotifyAPI.delete := SpotifyAPI.post(f"me/following?type=artist&ids={artist_id}", {})
+    return [TextContent(type="text", text=f"Unfollowed artist {artist_id}.")]
+
+@app.tool(description=tool_desc("Remove tracks from playlist.", "Remove specific tracks.", None))
+async def remove_tracks_from_playlist(playlist_id:Annotated[str,Field(description="Playlist ID")], uris:Annotated[List[str],Field(description="Track URIs")]) -> List[TextContent]:
+    payload = {"tracks": [{"uri": u} for u in uris]}
+    data = await SpotifyAPI.post(f"playlists/{playlist_id}/tracks", {"uris": uris, "positions": []})
+    return [TextContent(type="json", text=json.dumps(data, indent=2))]
+
+@app.tool(description=tool_desc("Delete playlist.", "Delete a playlist.", None))
+async def delete_playlist(playlist_id:Annotated[str,Field(description="Playlist ID")]) -> List[TextContent]:
+    await SpotifyAPI.delete := SpotifyAPI.post(f"playlists/{playlist_id}/followers", {})
+    return [TextContent(type="text", text=f"Deleted playlist {playlist_id}.")]
+
+# ==== Run Server ==== 
+async def main():
+    print("🚀 ShadowFM Spotify Companion MCP Server starting...")
+    await app.run_async("streamable-http", host="0.0.0.0", port=9090)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/mcp_servers/spotify/requirements.txt
+++ b/mcp_servers/spotify/requirements.txt
@@ -1,0 +1,15 @@
+# FastMCP and MCP dependencies
+fastmcp
+mcp
+
+# HTTP client for API calls
+httpx
+
+# Data validation and settings
+pydantic
+
+# OpenAI (optional, used in other tools)
+openai
+
+# Environment variable loader
+python-dotenv


### PR DESCRIPTION
This PR enhances the `Shadow Listener MCP` with core Spotify features to enable a richer and more interactive experience for users.

**New Capabilities:**

* `get_top_tracks` and `get_top_artists`
* `get_recommendations` based on listening behavior
* `get_audio_features` for detailed song analysis
* `get_currently_playing` to reflect real-time playback
* `control_playback` (play, pause, skip)
* `follow_artist` and `unfollow_artist`
* `remove_tracks_from_playlist` and `delete_playlist`

These additions build on existing tools like `analyze_listening_shift`, `get_listener_identity`, and `predict_future_taste`.

**Run Locally**

```bash
python spotify_shadow_listener_mcp.py
```

The MCP server runs at `http://localhost:9090` and uses a bearer token (`shadow-spotify-token` by default).

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New MCP feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes 