### PR TITLE
feat(tavily): add Tavily MCP server with search, extract, crawl, and map

### DIFF
--- a/mcp_servers/tavily/.env.example
+++ b/mcp_servers/tavily/.env.example
@@ -1,0 +1,2 @@
+TAVILY_API_KEY="your_api_key" # API key for Tavily
+TAVILY_MCP_SERVER_PORT=5000 # Port for the MCP server to listen on

--- a/mcp_servers/tavily/Dockerfile
+++ b/mcp_servers/tavily/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only the requirements first to leverage Docker cache
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the server code
+COPY server.py .
+COPY tools/ ./tools/
+
+# Expose the port the server runs on
+EXPOSE 5000
+
+# Command to run the MCP server
+CMD ["python", "server.py"]

--- a/mcp_servers/tavily/README.md
+++ b/mcp_servers/tavily/README.md
@@ -1,0 +1,186 @@
+# Tavily MCP Server
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python: 3.12+](https://img.shields.io/badge/Python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.100.0+-00a393.svg)](https://fastapi.tiangolo.com/)
+[![Tavily API](https://img.shields.io/badge/Tavily_API-v1-4b9ce2.svg)](https://docs.tavily.com)
+
+## 📖 Overview
+
+Tavily MCP Server is a Model Context Protocol (MCP) implementation that connects language models and other applications with the Tavily API. It provides a standardized interface for executing web search, extraction, crawling, and mapping operations through MCP tools.
+
+## 🚀 Features
+
+This server provides the following capabilities through MCP tools:
+
+| Tool | Description |
+|------|-------------|
+| `tavily_search` | Search the web with filters like topic, date range, domains, images, and raw content |
+| `tavily_extract` | Extract and parse content from one or more web pages |
+| `tavily_crawl` | Crawl a website starting from a root URL with depth/breadth controls |
+| `tavily_map` | Generate a website map without heavy content extraction |
+
+## 🔧 Prerequisites
+
+You'll need one of the following:
+
+- **Docker:** Docker installed and running (recommended)
+- **Python:** Python 3.12+ with pip
+- **Tavily API Key:** Get one from [Tavily](https://app.tavily.com)
+
+## ⚙️ Setup & Configuration
+
+### Environment Configuration
+
+1. **Create your environment file**:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Edit the `.env` file** with your Tavily API credentials:
+   ```
+   TAVILY_API_KEY=YOUR_ACTUAL_TAVILY_API_KEY
+   TAVILY_MCP_SERVER_PORT=5000
+   ```
+
+## 🏃‍♂️ Running the Server
+
+### Option 1: Docker (Recommended)
+
+The Docker build must be run from the project root directory (`klavis/`):
+
+```bash
+# Navigate to the root directory of the project
+cd /path/to/klavis
+
+# Build the Docker image
+docker build -t tavily-mcp-server -f mcp_servers/tavily/Dockerfile .
+
+# Run the container
+docker run -d -p 5000:5000 --env-file mcp_servers/tavily/.env --name tavily-mcp tavily-mcp-server
+```
+
+### Option 2: Python Virtual Environment
+
+```bash
+# Navigate to the Tavily server directory
+cd mcp_servers/tavily
+
+# Create and activate virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the server
+python server.py
+```
+
+Once running, the server will be accessible at `http://localhost:5000`.
+
+## 🔌 API Usage
+
+The server implements the Model Context Protocol (MCP) standard. Here's an example of how to call a tool:
+
+```python
+import httpx
+
+async def call_tavily_tool():
+    url = "http://localhost:5000/mcp"
+    payload = {
+        "tool_name": "tavily_search",
+        "tool_args": {
+            "query": "multi-agent Retrieval-Augmented Generation",
+            "topic": "news",
+            "max_results": 5,
+            "include_images": True
+        }
+    }
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=payload)
+        result = response.json()
+        return result
+```
+
+## 📋 Common Operations
+
+### Tavily Search
+
+```python
+payload = {
+    "tool_name": "tavily_search",
+    "tool_args": {
+        "query": "multi-agent RAG frameworks",
+        "topic": "news",
+        "max_results": 5,
+        "include_images": True
+    }
+}
+```
+
+### Tavily Extract
+
+```python
+payload = {
+    "tool_name": "tavily_extract",
+    "tool_args": {
+        "urls": ["https://www.python.org"],
+        "extract_depth": "advanced",
+        "include_images": True
+    }
+}
+```
+
+### Tavily Crawl
+
+```python
+payload = {
+    "tool_name": "tavily_crawl",
+    "tool_args": {
+        "url": "https://example.com",
+        "max_depth": 2,
+        "limit": 10
+    }
+}
+```
+
+### Tavily Map
+
+```python
+payload = {
+    "tool_name": "tavily_map",
+    "tool_args": {
+        "url": "https://example.com",
+        "max_depth": 1
+    }
+}
+```
+
+## 🛠️ Troubleshooting
+
+### Docker Build Issues
+
+- **File Not Found Errors**: Ensure you are building from the root project directory (`klavis/`), not from the server directory.
+
+### Common Runtime Issues
+
+- **Authentication Failures**: Verify your API key is correct and has not expired.
+- **API Errors**: Check the Tavily API documentation for error meanings.
+- **Rate Limiting**: Tavily may have usage limits depending on your plan.
+- **Invalid Arguments**: Make sure your payload matches the expected schema for each tool.
+
+## 🤝 Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## 📜 License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/mcp_servers/tavily/requirements.txt
+++ b/mcp_servers/tavily/requirements.txt
@@ -1,0 +1,9 @@
+tavily-python
+python-dotenv
+pydantic
+mcp[cli]>=1.12.0
+starlette
+uvicorn[standard]
+click
+typing-extensions
+httpx

--- a/mcp_servers/tavily/server.py
+++ b/mcp_servers/tavily/server.py
@@ -1,0 +1,304 @@
+import os
+import json
+import logging
+import contextlib
+from collections.abc import AsyncIterator
+from typing import Any, Dict
+
+import click
+from dotenv import load_dotenv
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.sse import SseServerTransport
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Mount, Route
+from starlette.types import Receive, Scope, Send
+
+from tools import (
+    tavily_api_key_context,
+    tavily_search,
+    tavily_extract,
+    tavily_crawl,
+    tavily_map,
+)
+
+# Load env early
+load_dotenv()
+
+logger = logging.getLogger("tavily-mcp-server")
+logging.basicConfig(level=logging.INFO)
+
+TAVILY_MCP_SERVER_PORT = int(os.getenv("TAVILY_MCP_SERVER_PORT", "5000"))
+
+
+@click.command()
+@click.option("--port", default=TAVILY_MCP_SERVER_PORT, help="Port to listen on for HTTP")
+@click.option("--log-level", default="INFO", help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)")
+@click.option("--json-response", is_flag=True, default=True, help="Enable JSON responses for StreamableHTTP")
+def main(port: int, log_level: str, json_response: bool) -> int:
+    """Tavily MCP server with SSE + StreamableHTTP transports (LinkedIn-style)."""
+    logging.getLogger().setLevel(getattr(logging, log_level.upper(), logging.INFO))
+    app = Server("tavily-mcp-server")
+
+    # ----------------------------- Tool Registry -----------------------------#
+    @app.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="tavily_search",
+                description=(
+                    "Web Search (Tavily) — search the web with filters like topic/news, "
+                    "date range, domains, and optional images/raw content.\n"
+                    "Prompt hints: 'search web for', 'find recent articles about', 'get latest news on'"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["query"],
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query text."},
+                        "search_depth": {
+                            "type": "string",
+                            "enum": ["basic", "advanced"],
+                            "description": "Depth of search. 'basic' is faster; 'advanced' is deeper.",
+                            "default": "basic",
+                        },
+                        "topic": {
+                            "type": "string",
+                            "enum": ["general", "news"],
+                            "description": "Bias results to a topic area.",
+                            "default": "general",
+                        },
+                        "days": {"type": "integer", "description": "Look-back window in days for freshness.", "default": 3},
+                        "time_range": {
+                            "type": "string",
+                            "enum": ["day", "week", "month", "year"],
+                            "description": "Relative time window.",
+                        },
+                        "start_date": {"type": "string", "description": "Filter results after YYYY-MM-DD."},
+                        "end_date": {"type": "string", "description": "Filter results before YYYY-MM-DD."},
+                        "max_results": {
+                            "type": "integer",
+                            "minimum": 5,
+                            "maximum": 20,
+                            "description": "Number of results to return (5–20).",
+                            "default": 10,
+                        },
+                        "include_images": {"type": "boolean", "description": "Include relevant images.", "default": False},
+                        "include_image_descriptions": {
+                            "type": "boolean",
+                            "description": "Include descriptions for images.",
+                            "default": False,
+                        },
+                        "include_raw_content": {
+                            "type": "boolean",
+                            "description": "Include cleaned raw page content.",
+                            "default": False,
+                        },
+                        "include_domains": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Only include results from these domains.",
+                        },
+                        "exclude_domains": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Exclude results from these domains.",
+                        },
+                        "country": {"type": "string", "description": "Country code to bias results (e.g., 'us')."},
+                        "include_favicon": {"type": "boolean", "description": "Include site favicon URLs.", "default": False},
+                        # Accept common aliases too (LLM-friendly)
+                        "searchDepth": {"type": "string", "enum": ["basic", "advanced"]},
+                        "timeRange": {"type": "string", "enum": ["day", "week", "month", "year"]},
+                        "startDate": {"type": "string"},
+                        "endDate": {"type": "string"},
+                        "maxResults": {"type": "integer", "minimum": 5, "maximum": 20},
+                        "includeImages": {"type": "boolean"},
+                        "includeImageDescriptions": {"type": "boolean"},
+                        "includeRawContent": {"type": "boolean"},
+                        "includeDomains": {"type": "array", "items": {"type": "string"}},
+                        "excludeDomains": {"type": "array", "items": {"type": "string"}},
+                        "includeFavicon": {"type": "boolean"},
+                    },
+                },
+            ),
+            types.Tool(
+                name="tavily_extract",
+                description=(
+                    "Extract Web Content — fetch and parse content from one or more URLs. "
+                    "Supports 'basic'/'advanced' depth, markdown/text output, images, and favicons.\n"
+                    "Prompt hints: 'extract content', 'scrape web page', 'fetch page summary'"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["urls"],
+                    "properties": {
+                        "urls": {"type": "array", "items": {"type": "string"}, "description": "List of absolute URLs."},
+                        "extract_depth": {
+                            "type": "string",
+                            "enum": ["basic", "advanced"],
+                            "description": "Richer parsing with 'advanced'.",
+                            "default": "basic",
+                        },
+                        "include_images": {"type": "boolean", "default": False},
+                        "format": {"type": "string", "enum": ["markdown", "text"], "default": "markdown"},
+                        "include_favicon": {"type": "boolean", "default": False},
+                    },
+                },
+            ),
+            types.Tool(
+                name="tavily_crawl",
+                description=(
+                    "Crawl Website — start from a root URL and follow links with depth/breadth controls. "
+                    "Returns page content and metadata. Use for small, bounded explorations.\n"
+                    "Prompt hints: 'crawl site', 'explore site structure', 'get all pages under'"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {"type": "string", "description": "Root absolute URL to crawl."},
+                        "max_depth": {"type": "integer", "minimum": 1, "default": 1},
+                        "max_breadth": {"type": "integer", "minimum": 1, "default": 20},
+                        "limit": {"type": "integer", "minimum": 1, "default": 50},
+                        "instructions": {"type": "string"},
+                        "select_paths": {"type": "array", "items": {"type": "string"}},
+                        "select_domains": {"type": "array", "items": {"type": "string"}},
+                        "allow_external": {"type": "boolean", "default": False},
+                        "categories": {"type": "array", "items": {"type": "string"}},
+                        "extract_depth": {"type": "string", "enum": ["basic", "advanced"], "default": "basic"},
+                        "format": {"type": "string", "enum": ["markdown", "text"], "default": "markdown"},
+                        "include_favicon": {"type": "boolean", "default": False},
+                    },
+                },
+            ),
+            types.Tool(
+                name="tavily_map",
+                description=(
+                    "Generate Website Map — discover reachable URLs from a root without extracting heavy content. "
+                    "Great for structure lists.\n"
+                    "Prompt hints: 'map website', 'list all pages on', 'show site structure for'"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {"type": "string", "description": "Root absolute URL to map."},
+                        "max_depth": {"type": "integer", "minimum": 1, "default": 1},
+                        "max_breadth": {"type": "integer", "minimum": 1, "default": 20},
+                        "limit": {"type": "integer", "minimum": 1, "default": 50},
+                        "instructions": {"type": "string"},
+                        "select_paths": {"type": "array", "items": {"type": "string"}},
+                        "select_domains": {"type": "array", "items": {"type": "string"}},
+                        "allow_external": {"type": "boolean", "default": False},
+                        "categories": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            ),
+        ]
+
+    # ---------------------------- Tool Dispatcher ----------------------------#
+    @app.call_tool()
+    async def call_tool(name: str, arguments: Dict[str, Any]) -> list[types.TextContent]:
+        logger.info(f"call_tool: {name}")
+        logger.debug(f"raw arguments: {json.dumps(arguments, indent=2)}")
+
+        try:
+            if name == "tavily_search":
+                result = tavily_search(arguments)
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            if name == "tavily_extract":
+                result = tavily_extract(arguments)
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            if name == "tavily_crawl":
+                result = tavily_crawl(arguments)
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            if name == "tavily_map":
+                result = tavily_map(arguments)
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+            return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
+        except Exception as e:
+            logger.exception(f"Error executing tool {name}: {e}")
+            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+
+    # ------------------------------- Transports ------------------------------#
+    sse = SseServerTransport("/messages/")
+
+    async def handle_sse(request):
+        """
+        SSE transport endpoint.
+        If header 'x-tavily-key' is present, bind it for the request via ContextVar.
+        """
+        logger.info("Handling SSE connection")
+        api_key = request.headers.get("x-tavily-key") or request.headers.get("x-auth-token")
+        token = None
+        if api_key:
+            token = tavily_api_key_context.set(api_key)
+
+        try:
+            async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+                await app.run(streams[0], streams[1], app.create_initialization_options())
+        finally:
+            if token:
+                tavily_api_key_context.reset(token)
+        return Response()
+
+    session_manager = StreamableHTTPSessionManager(
+        app=app,
+        event_store=None,
+        json_response=json_response,
+        stateless=True,
+    )
+
+    async def handle_streamable_http(scope: Scope, receive: Receive, send: Send) -> None:
+        """
+        Streamable HTTP transport endpoint.
+        Accepts 'x-tavily-key' (preferred) or 'x-auth-token' header for per-request auth.
+        """
+        logger.info("Handling StreamableHTTP request")
+        headers = {k.decode("utf-8"): v.decode("utf-8") for k, v in scope.get("headers", [])}
+        api_key = headers.get("x-tavily-key") or headers.get("x-auth-token")
+        token = None
+        if api_key:
+            token = tavily_api_key_context.set(api_key)
+        try:
+            await session_manager.handle_request(scope, receive, send)
+        finally:
+            if token:
+                tavily_api_key_context.reset(token)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_app: Starlette) -> AsyncIterator[None]:
+        async with session_manager.run():
+            logger.info("Application started with dual transports!")
+            try:
+                yield
+            finally:
+                logger.info("Application shutting down...")
+
+    starlette_app = Starlette(
+        debug=True,
+        routes=[
+            Route("/sse", endpoint=handle_sse, methods=["GET"]),
+            Mount("/messages/", app=sse.handle_post_message),
+            Mount("/mcp", app=handle_streamable_http),
+        ],
+        lifespan=lifespan,
+    )
+
+    logger.info(f"Server starting on port {port} with dual transports:")
+    logger.info(f"  - SSE endpoint: http://localhost:{port}/sse")
+    logger.info(f"  - StreamableHTTP endpoint: http://localhost:{port}/mcp")
+
+    import uvicorn
+    uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_servers/tavily/tools/__init__.py
+++ b/mcp_servers/tavily/tools/__init__.py
@@ -1,0 +1,17 @@
+from .auth import tavily_api_key_context, get_tavily_client
+from .search import tavily_search
+from .extract import tavily_extract
+from .crawl import tavily_crawl
+from .map import tavily_map
+
+__all__ = [
+    # Auth/context
+    "tavily_api_key_context",
+    "get_tavily_client",
+
+    # Tools
+    "tavily_search",
+    "tavily_extract",
+    "tavily_crawl",
+    "tavily_map",
+]

--- a/mcp_servers/tavily/tools/auth.py
+++ b/mcp_servers/tavily/tools/auth.py
@@ -1,0 +1,37 @@
+import os
+import logging
+from contextvars import ContextVar
+
+from dotenv import load_dotenv
+from tavily import TavilyClient
+
+logger = logging.getLogger(__name__)
+
+# Load environment variables from .env if present
+load_dotenv()
+
+tavily_api_key_context: ContextVar[str] = ContextVar("tavily_api_key")
+
+
+def _get_env_api_key() -> str:
+    key = os.getenv("TAVILY_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "Tavily API key not found. Set TAVILY_API_KEY env var "
+            "or provide 'x-tavily-key'/'x-auth-token' header to the server."
+        )
+    return key
+
+
+def get_tavily_api_key() -> str:
+    """Get the Tavily API key for the current request (ContextVar → env)."""
+    try:
+        return tavily_api_key_context.get()
+    except LookupError:
+        return _get_env_api_key()
+
+
+def get_tavily_client() -> TavilyClient:
+    """Create a TavilyClient bound to the current request's API key."""
+    api_key = get_tavily_api_key()
+    return TavilyClient(api_key=api_key)

--- a/mcp_servers/tavily/tools/crawl.py
+++ b/mcp_servers/tavily/tools/crawl.py
@@ -1,0 +1,62 @@
+import logging
+from typing import Any, Dict, List
+
+from .auth import get_tavily_client
+
+logger = logging.getLogger(__name__)
+
+
+def tavily_crawl(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Crawl Website — start from a root URL and follow links with depth/breadth controls.
+    Expected args include: url (required), max_depth, max_breadth, limit,
+    instructions, select_paths, select_domains, allow_external, categories,
+    extract_depth, format, include_favicon.
+    """
+    client = get_tavily_client()
+
+    url = arguments.get("url")
+    if not url:
+        raise RuntimeError("Parameter 'url' is required for tavily_crawl")
+
+    params: Dict[str, Any] = {
+        "url": url,
+        "max_depth": arguments.get("max_depth", 1),
+        "max_breadth": arguments.get("max_breadth", 20),
+        "limit": arguments.get("limit", 50),
+        "instructions": arguments.get("instructions"),
+        "select_paths": arguments.get("select_paths") or [],
+        "select_domains": arguments.get("select_domains") or [],
+        "allow_external": arguments.get("allow_external", False),
+        "categories": arguments.get("categories") or [],
+        "extract_depth": arguments.get("extract_depth", "basic"),
+        "format": arguments.get("format", "markdown"),
+        "include_favicon": arguments.get("include_favicon", False),
+    }
+
+    def _b(v: Any) -> Any:
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            s = v.strip().lower()
+            if s in {"true", "1", "yes", "y"}:
+                return True
+            if s in {"false", "0", "no", "n"}:
+                return False
+        return v
+
+    def _i(v: Any) -> Any:
+        if isinstance(v, int):
+            return v
+        if isinstance(v, str) and v.strip().isdigit():
+            return int(v)
+        return v
+
+    for k in ("max_depth", "max_breadth", "limit"):
+        params[k] = _i(params[k])
+
+    for k in ("allow_external", "include_favicon"):
+        params[k] = _b(params[k])
+
+    logger.info(f"tavily_crawl: {url}")
+    return client.crawl(**{k: v for k, v in params.items() if v is not None})

--- a/mcp_servers/tavily/tools/extract.py
+++ b/mcp_servers/tavily/tools/extract.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any, Dict, List
+
+from .auth import get_tavily_client
+
+logger = logging.getLogger(__name__)
+
+
+def tavily_extract(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Extract Web Content — fetch and parse content from one or more URLs.
+    Expected args: urls (List[str]), extract_depth, include_images, format, include_favicon
+    """
+    client = get_tavily_client()
+
+    urls = arguments.get("urls")
+    if not urls or not isinstance(urls, list):
+        raise RuntimeError("Parameter 'urls' (list) is required for tavily_extract")
+
+    params: Dict[str, Any] = {
+        "urls": urls,
+        "extract_depth": arguments.get("extract_depth", "basic"),
+        "include_images": arguments.get("include_images", False),
+        "format": arguments.get("format", "markdown"),
+        "include_favicon": arguments.get("include_favicon", False),
+    }
+
+    # Coerce booleans passed as strings
+    def _b(v: Any) -> Any:
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            s = v.strip().lower()
+            if s in {"true", "1", "yes", "y"}:
+                return True
+            if s in {"false", "0", "no", "n"}:
+                return False
+        return v
+
+    params["include_images"] = _b(params["include_images"])
+    params["include_favicon"] = _b(params["include_favicon"])
+
+    logger.info(f"tavily_extract: {len(urls)} url(s)")
+    return client.extract(**{k: v for k, v in params.items() if v is not None})

--- a/mcp_servers/tavily/tools/map.py
+++ b/mcp_servers/tavily/tools/map.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Any, Dict
+
+from .auth import get_tavily_client
+
+logger = logging.getLogger(__name__)
+
+
+def tavily_map(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Generate Website Map — discover reachable URLs from a root without heavy extraction.
+    Expected args include: url (required), max_depth, max_breadth, limit,
+    instructions, select_paths, select_domains, allow_external, categories.
+    """
+    client = get_tavily_client()
+
+    url = arguments.get("url")
+    if not url:
+        raise RuntimeError("Parameter 'url' is required for tavily_map")
+
+    params: Dict[str, Any] = {
+        "url": url,
+        "max_depth": arguments.get("max_depth", 1),
+        "max_breadth": arguments.get("max_breadth", 20),
+        "limit": arguments.get("limit", 50),
+        "instructions": arguments.get("instructions"),
+        "select_paths": arguments.get("select_paths") or [],
+        "select_domains": arguments.get("select_domains") or [],
+        "allow_external": arguments.get("allow_external", False),
+        "categories": arguments.get("categories") or [],
+    }
+
+    # Coercions
+    def _b(v: Any) -> Any:
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            s = v.strip().lower()
+            if s in {"true", "1", "yes", "y"}:
+                return True
+            if s in {"false", "0", "no", "n"}:
+                return False
+        return v
+
+    def _i(v: Any) -> Any:
+        if isinstance(v, int):
+            return v
+        if isinstance(v, str) and v.strip().isdigit():
+            return int(v)
+        return v
+
+    for k in ("max_depth", "max_breadth", "limit"):
+        params[k] = _i(params[k])
+
+    params["allow_external"] = _b(params["allow_external"])
+
+    logger.info(f"tavily_map: {url}")
+    return client.map(**{k: v for k, v in params.items() if v is not None})

--- a/mcp_servers/tavily/tools/search.py
+++ b/mcp_servers/tavily/tools/search.py
@@ -1,0 +1,95 @@
+import logging
+from typing import Any, Dict
+
+from .auth import get_tavily_client
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_KEYS = {
+    "query",
+    "search_depth",
+    "topic",
+    "days",
+    "time_range",
+    "start_date",
+    "end_date",
+    "max_results",
+    "include_images",
+    "include_image_descriptions",
+    "include_raw_content",
+    "include_domains",
+    "exclude_domains",
+    "country",
+    "include_favicon",
+}
+
+_ALIASES = {
+    "searchDepth": "search_depth",
+    "timeRange": "time_range",
+    "startDate": "start_date",
+    "endDate": "end_date",
+    "maxResults": "max_results",
+    "includeImages": "include_images",
+    "includeImageDescriptions": "include_image_descriptions",
+    "includeRawContent": "include_raw_content",
+    "includeDomains": "include_domains",
+    "excludeDomains": "exclude_domains",
+    "includeFavicon": "include_favicon",
+}
+
+
+def _coerce_bool(v: Any) -> Any:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s in {"true", "1", "yes", "y"}:
+            return True
+        if s in {"false", "0", "no", "n"}:
+            return False
+    return v
+
+
+def _coerce_int(v: Any) -> Any:
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str):
+        s = v.strip()
+        if s.isdigit():
+            return int(s)
+    return v
+
+
+def _normalize_args(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    # apply aliases
+    norm: Dict[str, Any] = {}
+    for k, v in arguments.items():
+        key = _ALIASES.get(k, k)
+        norm[key] = v
+
+    # keep only allowed keys
+    norm = {k: v for k, v in norm.items() if k in _ALLOWED_KEYS}
+
+    # basic coercions
+    if "max_results" in norm:
+        norm["max_results"] = _coerce_int(norm["max_results"])
+
+    for b in ("include_images", "include_image_descriptions", "include_raw_content", "include_favicon"):
+        if b in norm:
+            norm[b] = _coerce_bool(norm[b])
+
+    return norm
+
+
+def tavily_search(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Web Search (Tavily).
+    Arguments: see server list_tools schema; this function expects a plain dict.
+    Returns a dict as provided by Tavily's client.
+    """
+    client = get_tavily_client()
+    params = _normalize_args(arguments)
+    if "query" not in params or not params["query"]:
+        raise RuntimeError("Parameter 'query' is required for tavily_search")
+    logger.info(f"tavily_search: {params.get('query')}")
+    return client.search(**params)


### PR DESCRIPTION
## Description
This PR adds the Tavily MCP Server implementation, providing four fully functional tools for web search, content extraction, crawling, and site mapping via the [Tavily API](https://docs.tavily.com/).
The server supports both SSE and Streamable HTTP transports, making it compatible with clients like Claude Desktop and Cursor.

Key features included:
- tavily_search – Rich web search with filters for topic, date range, domains, and images
- tavily_extract – Extract and parse clean content from one or more URLs
- tavily_crawl – Crawl a site with configurable depth, breadth, and result limits
- tavily_map – Quickly map URLs from a site without full content extraction
- Robust error handling for invalid inputs, API failures, and rate limits
- Configurable via environment variables or request headers (x-tavily-key)

This aligns with Klavis AI’s MCP server guidelines for atomic tools, clear documentation, and proof-of-correctness testing.

## Type of change
- [ ] New MCP server 


## How has this been tested?
Testing Demo: https://drive.google.com/file/d/1Zlv2d2JXcz7ra_cLemc9B-MfDTeb6vMs/view?usp=sharing

