### PR TITLE
fix: Asana multi-workspace issue

### DIFF
--- a/mcp_servers/asana/server.py
+++ b/mcp_servers/asana/server.py
@@ -101,7 +101,7 @@ def main(
         return [
             types.Tool(
                 name="asana_create_task",
-                description="Create a new task in Asana",
+                description="Create a new task in Asana. You MUST call asana_get_workspaces first to get the workspace_id for the task.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -143,7 +143,7 @@ def main(
                             "description": "List of tag names or IDs",
                         },
                     },
-                    "required": ["name"],
+                    "required": ["name", "workspace_id"],
                 },
             ),
             types.Tool(
@@ -168,7 +168,7 @@ def main(
             ),
             types.Tool(
                 name="asana_search_tasks",
-                description="Search for tasks in Asana",
+                description="Search for tasks in Asana. You MUST call asana_get_workspaces first to get the workspace_id for the task.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -242,7 +242,7 @@ def main(
                             "description": "Sort order (default: descending)",
                         },
                     },
-                    "required": [],
+                    "required": ["workspace_id"],
                 },
             ),
             types.Tool(
@@ -357,7 +357,7 @@ def main(
             ),
             types.Tool(
                 name="asana_get_projects",
-                description="Get projects from Asana",
+                description="Get projects from Asana. You MUST call asana_get_workspaces first to get the workspace_id for the project.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -380,7 +380,7 @@ def main(
                             "description": "Token for pagination",
                         },
                     },
-                    "required": [],
+                    "required": ["workspace_id"],
                 },
             ),
             types.Tool(
@@ -433,7 +433,7 @@ def main(
             ),
             types.Tool(
                 name="asana_get_users",
-                description="Get users from Asana",
+                description="Get users from Asana. You MUST call asana_get_workspaces first to get the workspace_id for the user.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -452,7 +452,7 @@ def main(
                             "description": "Token for pagination",
                         },
                     },
-                    "required": [],
+                    "required": ["workspace_id"],
                 },
             ),
             types.Tool(
@@ -471,7 +471,7 @@ def main(
             ),
             types.Tool(
                 name="asana_get_teams",
-                description="Get teams from Asana",
+                description="Get teams from Asana. You MUST call asana_get_workspaces first to get the workspace_id for the team.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -490,7 +490,7 @@ def main(
                             "description": "Token for pagination",
                         },
                     },
-                    "required": [],
+                    "required": ["workspace_id"],
                 },
             ),
             types.Tool(
@@ -533,7 +533,7 @@ def main(
             ),
             types.Tool(
                 name="asana_get_tags",
-                description="Get tags from Asana",
+                description="Get tags from Asana. You MUST call asana_get_workspaces first to get the workspace_id for the tag.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -552,7 +552,7 @@ def main(
                             "description": "Token for pagination",
                         },
                     },
-                    "required": [],
+                    "required": ["workspace_id"],
                 },
             ),
             types.Tool(
@@ -571,7 +571,7 @@ def main(
             ),
             types.Tool(
                 name="asana_create_tag",
-                description="Create a tag in Asana",
+                description="Create a tag in Asana. You MUST call asana_get_workspaces first to get the workspace_id for the tag.",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -593,7 +593,7 @@ def main(
                             "description": "The workspace ID to create the tag in",
                         },
                     },
-                    "required": ["name"],
+                    "required": ["name", "workspace_id"],
                 },
             ),
         ]


### PR DESCRIPTION
## Description
Starting June 2025, Asana deprecated cross-workspace access capability. which means for some endpoints, if you have multiple workspaces, you MUST specify workspace_id. 

**P.S. though Asana endpoint itself doesn't set workspace_id as `required` because it can work for single workspace use case, but at Klavis tool design, we set workspace_id as `required` and update the tool description in the PR**


## Related
<img width="680" height="412" alt="Screenshot 2025-08-22 at 12 42 12 PM" src="https://github.com/user-attachments/assets/6c9edc40-2776-497b-9632-9ac039754f5a" />

<img width="1338" height="1240" alt="Screenshot 2025-08-22 at 12 10 24 PM" src="https://github.com/user-attachments/assets/c479a427-7592-47b9-92c7-669ee7e372e4" />


## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New MCP feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
<!-- Describe how you have tested these changes. -->

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 