### PR TITLE
docs(docs.json): Adds Claude Code in knowledge-base

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -302,7 +302,7 @@
           },
           {
             "group": "Developer",
-            "pages": ["knowledge-base/developer/chatgpt", "knowledge-base/developer/claude_desktop", "knowledge-base/developer/cline", "knowledge-base/developer/continue",  "knowledge-base/developer/cursor","knowledge-base/developer/github_copilot","knowledge-base/developer/kiro","knowledge-base/developer/windsurf"]
+            "pages": ["knowledge-base/developer/chatgpt","knowledge-base/developer/claude_code", "knowledge-base/developer/claude_desktop", "knowledge-base/developer/cline", "knowledge-base/developer/continue",  "knowledge-base/developer/cursor","knowledge-base/developer/github_copilot","knowledge-base/developer/kiro","knowledge-base/developer/windsurf"]
           },
           {
             "group": "OAuth Apps",


### PR DESCRIPTION
## Description
While resolving conflicts between Claude Code and ChatGPT, made this small mistake.
Fixes and adds Claude Code to appear in Docs.

## Related issue


## Type of change
<!-- Please delete options that are not relevant -->
- [x] Documentation update

## How has this been tested?
(Add screenshots or recordings here if applicable.)

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have made corresponding changes to the documentation