### PR TITLE
override get_oauth_url endpoint to update sdk

### DIFF
--- a/fern/overrides.yml
+++ b/fern/overrides.yml
@@ -51,3 +51,163 @@ paths:
     post:
       x-fern-sdk-group-name: mcp_server
       x-fern-sdk-method-name: get_oauth_url
+  "/oauth/slack/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_slack
+  "/oauth/github/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_github
+  "/oauth/gitlab/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gitlab
+  "/oauth/supabase/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_supabase
+  "/oauth/notion/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_notion
+  "/oauth/jira/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_jira
+  "/oauth/confluence/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_confluence
+  "/oauth/wordpress/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_wordpress
+  "/oauth/gmail/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gmail
+  "/oauth/gdrive/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gdrive
+  "/oauth/gcalendar/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gcalendar
+  "/oauth/gsheets/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gsheets
+  "/oauth/gdocs/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_gdocs
+  "/oauth/attio/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_attio
+  "/oauth/salesforce/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_salesforce
+  "/oauth/asana/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_asana
+  "/oauth/linear/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_linear
+  "/oauth/close/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_close
+  "/oauth/clickup/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_clickup
+  "/oauth/airtable/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_airtable
+  "/oauth/hubspot/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_hubspot
+  "/oauth/linkedin/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_linkedin
+  "/oauth/canva/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_canva
+  "/oauth/xero/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_xero
+  "/oauth/dropbox/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_dropbox
+  "/oauth/box/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_box
+  "/oauth/quickbooks/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_quickbooks
+  "/oauth/zendesk/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_zendesk
+  "/oauth/stripe/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_stripe
+  "/oauth/calcom/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_calcom
+  "/oauth/vercel/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_vercel
+  "/oauth/pipedrive/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_pipedrive
+  "/oauth/figma/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_figma
+  "/oauth/klaviyo/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_klaviyo
+  "/oauth/pagerduty/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_pagerduty
+  "/oauth/docusign/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_docusign
+  "/oauth/dialpad/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_dialpad
+  "/oauth/shopify/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_shopify
+  "/oauth/onedrive/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_onedrive
+  "/oauth/outlook/authorize":
+    get:
+      x-fern-sdk-group-name: oauth
+      x-fern-sdk-method-name: authorize_outlook

--- a/fern/overrides.yml
+++ b/fern/overrides.yml
@@ -35,12 +35,19 @@ paths:
   "/mcp-server/call-tool":
     post:
       operationId: call_tools
-      x-fern-method-name: call_tools
+      x-fern-sdk-group-name: mcp_server
+      x-fern-sdk-method-name: call_tools
   "/mcp-server/list-tools":
     post:
       operationId: list_tools
-      x-fern-method-name: list_tools
+      x-fern-sdk-group-name: mcp_server
+      x-fern-sdk-method-name: list_tools
   "/mcp-server/tools/{server_name}":
     get:
       operationId: get_tools
-      x-fern-method-name: get_tools
+      x-fern-sdk-group-name: mcp_server
+      x-fern-sdk-method-name: get_tools
+  "/mcp-server/oauth-url":
+    post:
+      x-fern-sdk-group-name: mcp_server
+      x-fern-sdk-method-name: get_oauth_url


### PR DESCRIPTION
## Description
<!-- Please describe the changes in this PR. -->

based on fern doc - https://buildwithfern.com/learn/api-definitions/openapi/extensions/method-names
fix 2 issues:

1. change `get_o_auth_url` to `get_oauth_url`

2. put all oauth_xx within oauth folder : https://github.com/Klavis-AI/python-sdk/tree/main/src/klavis

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
<!-- e.g. Fixes #123 or Related to #456 -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New MCP feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
<!-- Describe how you have tested these changes. -->

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 