### PR TITLE
fix(google_sheets): correct worksheet validation in write_to_cell

### DIFF
--- a/mcp_servers/google_sheets/exceptions.py
+++ b/mcp_servers/google_sheets/exceptions.py
@@ -1,0 +1,13 @@
+# Error class for retryable errors
+class RetryableToolError(Exception):
+    def __init__(self, message: str, additional_prompt_content: str = "", retry_after_ms: int = 1000, developer_message: str = ""):
+        super().__init__(message)
+        self.additional_prompt_content = additional_prompt_content
+        self.retry_after_ms = retry_after_ms
+        self.developer_message = developer_message
+
+# Error class for tool execution errors
+class ToolExecutionError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message

--- a/mcp_servers/google_sheets/server.py
+++ b/mcp_servers/google_sheets/server.py
@@ -21,6 +21,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from exceptions import RetryableToolError
 from models import (
     SheetDataInput,
     Spreadsheet,
@@ -71,14 +72,6 @@ def extract_access_token(request_or_scope) -> str:
     except (json.JSONDecodeError, TypeError) as e:
         logger.warning(f"Failed to parse auth data JSON: {e}")
         return ""
-
-# Error class for retryable errors
-class RetryableToolError(Exception):
-    def __init__(self, message: str, additional_prompt_content: str = "", retry_after_ms: int = 1000, developer_message: str = ""):
-        super().__init__(message)
-        self.additional_prompt_content = additional_prompt_content
-        self.retry_after_ms = retry_after_ms
-        self.developer_message = developer_message
 
 def get_sheets_service(access_token: str):
     """Create Google Sheets service with access token."""

--- a/mcp_servers/google_sheets/utils.py
+++ b/mcp_servers/google_sheets/utils.py
@@ -4,6 +4,7 @@ from typing import Any
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import Resource, build
 
+from exceptions import RetryableToolError, ToolExecutionError
 from models import (
     CellData,
     CellExtendedValue,
@@ -494,18 +495,24 @@ def validate_write_to_cell_params(  # type: ignore[no-any-unimported]
         )
         .execute()
     )
-    sheet_names = [sheet["properties"]["title"] for sheet in sheet_properties["sheets"]]
-    sheet_row_count = sheet_properties["sheets"][0]["properties"]["gridProperties"]["rowCount"]
-    sheet_column_count = sheet_properties["sheets"][0]["properties"]["gridProperties"][
-        "columnCount"
-    ]
 
-    if sheet_name not in sheet_names:
+    target_sheet = None
+    for sheet in sheet_properties["sheets"]:
+        if sheet["properties"]["title"] == sheet_name:
+            target_sheet = sheet
+            break
+
+    sheet_names = [sheet["properties"]["title"] for sheet in sheet_properties["sheets"]]
+
+    if target_sheet is None:
         raise RetryableToolError(
             message=f"Sheet name {sheet_name} not found in spreadsheet with id {spreadsheet_id}",
             additional_prompt_content=f"Sheet names in the spreadsheet: {sheet_names}",
             retry_after_ms=100,
         )
+
+    sheet_row_count = target_sheet["properties"]["gridProperties"]["rowCount"]
+    sheet_column_count = target_sheet["properties"]["gridProperties"]["columnCount"]
 
     if row > sheet_row_count:
         raise ToolExecutionError(


### PR DESCRIPTION
## Description
- Fix bug where write_to_cell validated against the first sheet's dimensions instead of the target sheet, causing false
  out-of-bounds errors when writing to non-first sheets.
- Fix missing imports: `utils.py` was using `RetryableToolError` and `ToolExecutionError` but wasn't importing them. Extracted these classes into a new `exceptions.py` module that both `server.py` and `utils.py` can import.

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
<!-- e.g. Fixes #123 or Related to #456 -->
N/A

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Tested using Claude Code with multi-sheet spreadsheets.

### Test scenarios:
  - Writing to cells in the first sheet (existing behavior preserved)
  - Writing to cells in non-first sheets (bug fix verified)
  - Out-of-bounds validation for different sheet sizes (correctly validates per-sheet)
  - Error messages display correct sheet information

<video src="https://github.com/user-attachments/assets/8dcf2063-ed1e-43ae-9e34-b7f6532440d1"></video>

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 