### PR TITLE
refactor(mcp-servers): use json.dumps instead of str for TextContent

### DIFF
--- a/mcp_servers/discord/server.py
+++ b/mcp_servers/discord/server.py
@@ -552,7 +552,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -563,7 +563,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -576,7 +576,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -588,7 +588,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -600,7 +600,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -612,7 +612,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -623,7 +623,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -634,7 +634,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         
@@ -644,7 +644,7 @@ def main(
             return [
                 types.TextContent(
                     type="text",
-                    text=str(result),
+                    text=json.dumps(result, indent=2),
                 )
             ]
         

--- a/mcp_servers/google_docs/server.py
+++ b/mcp_servers/google_docs/server.py
@@ -376,7 +376,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -388,13 +388,13 @@ def main(
                     )
                 ]
         
-        elif name == "google_docs_get_all_documents":            
+        elif name == "google_docs_get_all_documents":
             try:
                 result = await get_all_documents()
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -422,7 +422,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -449,7 +449,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -477,7 +477,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:

--- a/mcp_servers/google_sheets/server.py
+++ b/mcp_servers/google_sheets/server.py
@@ -398,7 +398,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -425,7 +425,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -457,7 +457,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -475,7 +475,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:

--- a/mcp_servers/hubspot/server.py
+++ b/mcp_servers/hubspot/server.py
@@ -857,7 +857,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -883,7 +883,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -977,7 +977,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1003,7 +1003,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1097,7 +1097,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1123,7 +1123,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1141,7 +1141,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1217,7 +1217,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1243,7 +1243,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1261,7 +1261,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1371,7 +1371,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1397,7 +1397,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:
@@ -1415,7 +1415,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:

--- a/mcp_servers/quickbooks/server.py
+++ b/mcp_servers/quickbooks/server.py
@@ -149,8 +149,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextCont
             if isinstance(result, list):
                 if not result:
                     return [types.TextContent(type="text", text="No results found.")]
-                return [types.TextContent(type="text", text=str(result))]
-        return [types.TextContent(type="text", text=str(result))]
+                return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
     except Exception as e:
         import traceback
         logger.error(

--- a/mcp_servers/youtube/server.py
+++ b/mcp_servers/youtube/server.py
@@ -247,7 +247,7 @@ def main(
                 return [
                     types.TextContent(
                         type="text",
-                        text=str(result),
+                        text=json.dumps(result, indent=2),
                     )
                 ]
             except Exception as e:


### PR DESCRIPTION
## Description

Replace `str(result)` with `json.dumps(result, indent=2)` in 6 MCP servers to align with repo standard and improve client-side parsing.

## Motivation

We discovered this pattern while building UX features that parse MCP tool responses. When responses use `str(result)`, we need Python-specific `ast.literal_eval()` to parse them. Using `json.dumps()` instead provides:
- **Client-side parsing**: Enables standard JSON parsing for UX features (displaying structured data, filtering results, etc.)
- **Consistency**: Aligns with 317 existing uses of `json.dumps(result, indent=2)` across the repo
- **Interoperability**: JSON format is language-agnostic vs Python's `str()` representation

Note: Both formats are technically valid per MCP spec (TextContent.text is just a string) and work equally well for LLMs reading responses.

## Type of change

- [x] Refactor (code change that improves consistency without changing functionality)

## How has this been tested?

Not tested manually as this is a straightforward serialization change. The change:
- Maintains the same data structure
- Uses an established pattern in the codebase (317 existing occurrences)
- LLMs can read both formats equally well

## Affected servers

- google_docs (5 occurrences)
- discord (9 occurrences)  
- google_sheets (4 occurrences)
- quickbooks (2 occurrences)
- youtube (1 occurrence)
- hubspot (13 occurrences)

## Checklist

- [x] I have performed a self-review of my own code
- [x] Changes align with existing code patterns in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)