### PR TITLE
build(deps): bump starlette from 0.47.2 to 0.49.1 in /mcp_servers/google_slides

### DIFF
--- a/mcp_servers/google_slides/requirements.txt
+++ b/mcp_servers/google_slides/requirements.txt
@@ -1,5 +1,5 @@
 # Server dependencies
-starlette==0.47.2
+starlette==0.49.1
 uvicorn==0.30.0
 click==8.1.7
 python-dotenv==1.0.1


### PR DESCRIPTION
## Description
Bumps [starlette](https://github.com/Kludex/starlette) from 0.47.2 to 0.49.1

## Related issue
Issue: https://github.com/Klavis-AI/klavis/security/dependabot/71

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Security Fix

## How has this been tested?

## Checklist