### PR TITLE
build(deps): bump starlette  to 0.49.1 in multiple files of /mcp_servers

### DIFF
--- a/mcp_servers/calendly/requirements.txt
+++ b/mcp_servers/calendly/requirements.txt
@@ -7,4 +7,4 @@ aiohttp>=3.8.0
 httpx>=0.27.0
 python-dotenv>=1.0.0
 typing-extensions
-starlette>=0.27.0
+starlette>=0.49.1

--- a/mcp_servers/exa/requirements.txt
+++ b/mcp_servers/exa/requirements.txt
@@ -3,5 +3,5 @@ exa_py==1.15.1
 python-dotenv==1.1.1
 httpx>=0.28.1
 click>=8.2.1
-starlette>=0.47.2
+starlette>=0.49.1
 uvicorn>=0.35.0

--- a/mcp_servers/figma/requirements.txt
+++ b/mcp_servers/figma/requirements.txt
@@ -7,4 +7,4 @@ aiohttp>=3.8.0
 httpx>=0.27.0
 python-dotenv>=1.0.0
 typing-extensions
-starlette>=0.27.0
+starlette>=0.49.1

--- a/mcp_servers/freshdesk/requirements.txt
+++ b/mcp_servers/freshdesk/requirements.txt
@@ -1,5 +1,5 @@
 mcp==1.11.0
-starlette>=0.40.0
+starlette>=0.49.1
 uvicorn>=0.32.1
 click>=8.1.7
 python-dotenv>=1.0.1

--- a/mcp_servers/google_jobs/requirements.txt
+++ b/mcp_servers/google_jobs/requirements.txt
@@ -1,7 +1,7 @@
 mcp==1.11.0
 python-dotenv>=1.0.0
 typing-extensions>=4.8.0
-starlette>=0.36.0
+starlette>=0.49.1
 uvicorn[standard]>=0.24.0
 aiohttp>=3.9.0
 click>=8.1.0

--- a/mcp_servers/heygen/requirements.txt
+++ b/mcp_servers/heygen/requirements.txt
@@ -2,5 +2,5 @@ click>=8.0.0
 httpx>=0.25.0
 mcp==1.11.0
 python-dotenv>=1.0.0
-starlette>=0.32.0
+starlette>=0.49.1
 uvicorn>=0.24.0

--- a/mcp_servers/hubspot/requirements.txt
+++ b/mcp_servers/hubspot/requirements.txt
@@ -27,7 +27,7 @@ shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
 sse-starlette==2.3.6
-starlette==0.47.2
+starlette==0.49.1
 typer==0.16.0
 typing-inspection==0.4.1
 typing_extensions==4.14.0

--- a/mcp_servers/linkedin/requirements.txt
+++ b/mcp_servers/linkedin/requirements.txt
@@ -7,4 +7,4 @@ aiohttp>=3.8.0
 httpx>=0.27.0
 python-dotenv>=1.0.0
 typing-extensions
-starlette>=0.27.0
+starlette>=0.49.1

--- a/mcp_servers/mailchimp/requirements.txt
+++ b/mcp_servers/mailchimp/requirements.txt
@@ -7,4 +7,4 @@ aiohttp>=3.8.0
 httpx>=0.27.0
 python-dotenv>=1.0.0
 typing-extensions
-starlette>=0.27.0
+starlette>=0.49.1

--- a/mcp_servers/mem0/requirements.txt
+++ b/mcp_servers/mem0/requirements.txt
@@ -6,5 +6,5 @@ pydantic>=2.5.0
 httpx>=0.27.0
 python-dotenv>=1.0.0
 typing-extensions
-starlette>=0.27.0
+starlette>=0.49.1
 mem0ai>=0.1.115

--- a/mcp_servers/openrouter/requirements.txt
+++ b/mcp_servers/openrouter/requirements.txt
@@ -1,6 +1,6 @@
 mcp==1.11.0
 click>=8.0.0
-starlette>=0.27.0
+starlette>=0.49.1
 uvicorn>=0.24.0
 python-dotenv>=1.0.0
 httpx>=0.25.0

--- a/mcp_servers/salesforce/requirements.txt
+++ b/mcp_servers/salesforce/requirements.txt
@@ -1,5 +1,5 @@
 mcp==1.11.0
-starlette>=0.40.0
+starlette>=0.49.1
 uvicorn>=0.32.1
 click>=8.1.7
 python-dotenv>=1.0.1

--- a/mcp_servers/twilio/requirements.txt
+++ b/mcp_servers/twilio/requirements.txt
@@ -1,7 +1,7 @@
 mcp==1.11.0
 click>=8.0.0
 python-dotenv>=0.19.0
-starlette>=0.40.0
+starlette>=0.49.1
 twilio>=9.0.0
 pydantic>=2.0.0
 uvicorn>=0.30.0


### PR DESCRIPTION
## Description
Updates Starlette version to latest 0.49.1 to address security vulnerablity.

## Related issue
#669 

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Security Vulnerablity Fix

## How has this been tested?
(Add screenshots or recordings here if applicable.)

## Checklist
<!-- Please delete options that are not relevant -->