### PR TITLE
feat(google_sheets): consolidate range tools and add cell value format options

### DIFF
--- a/mcp_servers/google_sheets/utils.py
+++ b/mcp_servers/google_sheets/utils.py
@@ -339,12 +339,16 @@ def create_sheet_data(
     return sheet_data
 
 
-def parse_get_spreadsheet_response(api_response: dict) -> dict:
+def parse_get_spreadsheet_response(api_response: dict, cell_value_format: str) -> dict:
     """
     Parse the get spreadsheet Google Sheets API response into a structured dictionary.
+
+    Args:
+        api_response (dict): The API response from Google Sheets.
+        cell_value_format (str): Format of cell values - "formatted", "userEntered", or "all".
     """
     properties = api_response.get("properties", {})
-    sheets = [parse_sheet(sheet) for sheet in api_response.get("sheets", [])]
+    sheets = [parse_sheet(sheet, cell_value_format) for sheet in api_response.get("sheets", [])]
 
     return {
         "title": properties.get("title", ""),
@@ -354,14 +358,18 @@ def parse_get_spreadsheet_response(api_response: dict) -> dict:
     }
 
 
-def parse_sheet(api_sheet: dict) -> dict:
+def parse_sheet(api_sheet: dict, cell_value_format: str) -> dict:
     """
     Parse an individual sheet's data from the Google Sheets 'get spreadsheet'
     API response into a structured dictionary.
+
+    Args:
+        api_sheet (dict): The API response for a single sheet.
+        cell_value_format (str): Format of cell values - "formatted", "userEntered", or "all".
     """
     props = api_sheet.get("properties", {})
     grid_props = props.get("gridProperties", {})
-    cell_data = convert_api_grid_data_to_dict(api_sheet.get("data", []))
+    cell_data = convert_api_grid_data_to_dict(api_sheet.get("data", []), cell_value_format)
 
     return {
         "sheetId": props.get("sheetId"),
@@ -390,7 +398,7 @@ def extract_user_entered_cell_value(cell: dict) -> Any:
     return ""
 
 
-def process_row(row: dict, start_column_index: int) -> dict:
+def process_row(row: dict, start_column_index: int, cell_value_format: str) -> dict:
     """
     Process a single row from grid data, converting non-empty cells into a dictionary
     that maps column letters to cell values.
@@ -398,6 +406,7 @@ def process_row(row: dict, start_column_index: int) -> dict:
     Args:
         row (dict): A row from the grid data.
         start_column_index (int): The starting column index for this row.
+        cell_value_format (str): Format of cell values - "formatted", "userEntered", or "all".
 
     Returns:
         dict: A mapping of column letters to cell values for non-empty cells.
@@ -410,15 +419,20 @@ def process_row(row: dict, start_column_index: int) -> dict:
         formatted_cell_value = cell.get("formattedValue", "")
 
         if user_entered_cell_value != "" or formatted_cell_value != "":
-            row_result[column_string] = {
-                "userEnteredValue": user_entered_cell_value,
-                "formattedValue": formatted_cell_value,
-            }
+            if cell_value_format == "all":
+                row_result[column_string] = {
+                    "userEnteredValue": user_entered_cell_value,
+                    "formattedValue": formatted_cell_value,
+                }
+            elif cell_value_format == "userEntered":
+                row_result[column_string] = user_entered_cell_value
+            else:  # "formatted"
+                row_result[column_string] = formatted_cell_value
 
     return row_result
 
 
-def convert_api_grid_data_to_dict(grids: list[dict]) -> dict:
+def convert_api_grid_data_to_dict(grids: list[dict], cell_value_format: str) -> dict:
     """
     Convert a list of grid data dictionaries from the 'get spreadsheet' API
     response into a structured cell dictionary.
@@ -428,6 +442,7 @@ def convert_api_grid_data_to_dict(grids: list[dict]) -> dict:
 
     Args:
         grids (list[dict]): The list of grid data dictionaries from the API.
+        cell_value_format (str): Format of cell values - "formatted", "userEntered", or "all".
 
     Returns:
         dict: A dictionary mapping row numbers to dictionaries of column letter/value pairs.
@@ -440,7 +455,7 @@ def convert_api_grid_data_to_dict(grids: list[dict]) -> dict:
 
         for i, row in enumerate(grid.get("rowData", []), start=1):
             current_row = start_row + i
-            row_data = process_row(row, start_column)
+            row_data = process_row(row, start_column, cell_value_format)
 
             if row_data:
                 result[current_row] = row_data


### PR DESCRIPTION
## Description
Merge `google_sheets_get_range` into `google_sheets_get_spreadsheet` and add cell_value_format parameter to reduce context size for LLMs.

Why:
- LLMs often only need display values, not formulas
- Returning both userEnteredValue and formattedValue wastes tokens
- Different use cases need different formats (display vs calculation logic)
  - Reference: https://www.anthropic.com/engineering/writing-tools-for-agents#returning-meaningful-context-from-your-tools

Changes:
- Remove google_sheets_get_range tool (functionality merged into get_spreadsheet)
- Add optional 'range' parameter for filtering
- Add 'cell_value_format' parameter: 'formatted' (default), 'userEntered', 'all'
- Request only needed fields from Google Sheets API

Benefits:
- Reduces token usage when formulas are not needed
- More efficient API requests

## Related PR
- Added the feature at https://github.com/Klavis-AI/klavis/pull/653

## Type of change
- [x] New MCP feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - (Though MCP server remains backward compatible overall)

## How has this been tested?
Test Method
- Retrieved specific column data from large spreadsheets (only formatted value)
- Performed grouping and aggregation (count/sum) on that data
- Tested different cell_value_format options (formatted/userEntered/all) to verify parameter functionality
- Wrote calculated results to designated columns

Test Results
- Efficient retrieval of large datasets
- cell_value_format parameter functionality verified
- Maintained full functionality after tool consolidation

https://github.com/user-attachments/assets/7c7895ac-0e11-4cbd-b49c-ad3eef2bc5d9

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
<!-- - [ ] I have made corresponding changes to the documentation -->
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes 