### PR TITLE
fix(yahoo-finance): Add missing server name mapping

### DIFF
--- a/.github/workflows/server-name-mapping.json
+++ b/.github/workflows/server-name-mapping.json
@@ -9,5 +9,6 @@
   "google_sheets": "google-sheets",
   "google_slides": "google-slides",
   "hacker_news": "hacker-news",
-  "report_generation": "report-generation"
+  "report_generation": "report-generation",
+  "yahoo_finance": "yahoo-finance"
 }


### PR DESCRIPTION
## Description

Add yahoo_finance to server-name-mapping.json to ensure the folder name is correctly mapped to the yahoo-finance Docker image, as this mapping is currently inconsistent with the [README](https://github.com/devroopsaha744/klavis/blob/main/mcp_servers/yahoo_finance/README.md)

## Related PR
https://github.com/Klavis-AI/klavis/pull/645


## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - docker image name will change.
- [x] Documentation update

## How has this been tested?
N/A

## Checklist
- [x] I have made corresponding changes to the documentation