### PR TITLE
feat(google_jobs): add country and language parameters to search tools

### DIFF
--- a/mcp_servers/google_jobs/server.py
+++ b/mcp_servers/google_jobs/server.py
@@ -38,7 +38,7 @@ def extract_api_key(request_or_scope) -> str:
     """Extract API key from headers or environment."""
     api_key = os.getenv("API_KEY")
     auth_data = None
-    
+
     if not api_key:
         # Handle different input types (request object for SSE, scope dict for StreamableHTTP)
         if hasattr(request_or_scope, 'headers'):
@@ -52,7 +52,7 @@ def extract_api_key(request_or_scope) -> str:
             auth_data = headers.get(b'x-auth-data')
             if auth_data:
                 auth_data = base64.b64decode(auth_data).decode('utf-8')
-        
+
         if auth_data:
             try:
                 # Parse the JSON auth data to extract token
@@ -61,7 +61,7 @@ def extract_api_key(request_or_scope) -> str:
             except (json.JSONDecodeError, TypeError) as e:
                 logger.warning(f"Failed to parse auth data JSON: {e}")
                 api_key = ""
-    
+
     return api_key or ""
 
 @click.command()
@@ -82,7 +82,7 @@ def main(
     log_level: str,
     json_response: bool,
 ) -> int:
-    
+
     logging.basicConfig(
         level=getattr(logging, log_level.upper()),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -134,6 +134,14 @@ def main(
                             "type": "integer",
                             "description": "Starting position for pagination (default: 0)",
                             "default": 0
+                        },
+                        "country": {
+                            "type": "string",
+                            "description": "Country code for search results (e.g., 'us', 'jp', 'uk'). Defaults to 'us'."
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Language code for search results (e.g., 'en', 'ja', 'fr'). Defaults to 'en'."
                         }
                     }
                 },
@@ -178,6 +186,14 @@ def main(
                             "type": "integer",
                             "description": "Starting position for pagination (default: 0)",
                             "default": 0
+                        },
+                        "country": {
+                            "type": "string",
+                            "description": "Country code for search results (e.g., 'us', 'jp', 'uk'). Defaults to 'us'."
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Language code for search results (e.g., 'en', 'ja', 'fr'). Defaults to 'en'."
                         }
                     }
                 },
@@ -212,6 +228,14 @@ def main(
                             "type": "integer",
                             "description": "Starting position for pagination (default: 0)",
                             "default": 0
+                        },
+                        "country": {
+                            "type": "string",
+                            "description": "Country code for search results (e.g., 'us', 'jp', 'uk'). Defaults to 'us'."
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Language code for search results (e.g., 'en', 'ja', 'fr'). Defaults to 'en'."
                         }
                     }
                 },
@@ -238,7 +262,7 @@ def main(
     async def call_tool(
         name: str, arguments: dict
     ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
-        
+
         if name == "google_jobs_search":
             query = arguments.get("query")
             location = arguments.get("location")
@@ -248,7 +272,9 @@ def main(
             company = arguments.get("company")
             radius = arguments.get("radius")
             start = arguments.get("start", 0)
-            
+            country = arguments.get("country", "us")
+            language = arguments.get("language", "en")
+
             if not query:
                 return [
                     types.TextContent(
@@ -265,7 +291,9 @@ def main(
                     salary_min=salary_min,
                     company=company,
                     radius=radius,
-                    start=start
+                    start=start,
+                    country=country,
+                    language=language
                 )
                 return [
                     types.TextContent(
@@ -281,10 +309,10 @@ def main(
                         text=f"Error: {str(e)}",
                     )
                 ]
-        
+
         elif name == "google_jobs_get_details":
             job_id = arguments.get("job_id")
-            
+
             if not job_id:
                 return [
                     types.TextContent(
@@ -308,13 +336,15 @@ def main(
                         text=f"Error: {str(e)}",
                     )
                 ]
-        
+
         elif name == "google_jobs_search_by_company":
             company_name = arguments.get("company_name")
             location = arguments.get("location")
             employment_type = arguments.get("employment_type")
             start = arguments.get("start", 0)
-            
+            country = arguments.get("country", "us")
+            language = arguments.get("language", "en")
+
             if not company_name:
                 return [
                     types.TextContent(
@@ -327,7 +357,9 @@ def main(
                     company_name=company_name,
                     location=location,
                     employment_type=employment_type,
-                    start=start
+                    start=start,
+                    country=country,
+                    language=language
                 )
                 return [
                     types.TextContent(
@@ -343,14 +375,16 @@ def main(
                         text=f"Error: {str(e)}",
                     )
                 ]
-        
+
         elif name == "google_jobs_search_remote":
             query = arguments.get("query")
             employment_type = arguments.get("employment_type")
             date_posted = arguments.get("date_posted")
             salary_min = arguments.get("salary_min")
             start = arguments.get("start", 0)
-            
+            country = arguments.get("country", "us")
+            language = arguments.get("language", "en")
+
             if not query:
                 return [
                     types.TextContent(
@@ -364,7 +398,9 @@ def main(
                     employment_type=employment_type,
                     date_posted=date_posted,
                     salary_min=salary_min,
-                    start=start
+                    start=start,
+                    country=country,
+                    language=language
                 )
                 return [
                     types.TextContent(
@@ -380,10 +416,10 @@ def main(
                         text=f"Error: {str(e)}",
                     )
                 ]
-        
+
         elif name == "google_jobs_get_suggestions":
             query = arguments.get("query")
-            
+
             if not query:
                 return [
                     types.TextContent(
@@ -407,7 +443,7 @@ def main(
                         text=f"Error: {str(e)}",
                     )
                 ]
-        
+
         else:
             return [
                 types.TextContent(
@@ -421,9 +457,9 @@ def main(
     async def handle_sse(request: Request):
         """Handle SSE connections."""
         logger.info("Handling SSE connection")
-        
+
         auth_token = extract_api_key(request)
-        
+
         token = serpapi_token_context.set(auth_token or "")
         try:
             async with sse.connect_sse(
@@ -437,7 +473,7 @@ def main(
             return Response(f"Internal server error: {str(e)}", status_code=500)
         finally:
             serpapi_token_context.reset(token)
-        
+
         return Response()
 
     session_manager = StreamableHTTPSessionManager(
@@ -452,7 +488,7 @@ def main(
     ) -> None:
         """Handle StreamableHTTP requests."""
         logger.info(f"Handling StreamableHTTP request: {scope['method']} {scope['path']}")
-        
+
         if scope["method"] != "POST":
             await send({
                 "type": "http.response.start",
@@ -469,9 +505,9 @@ def main(
                 }).encode(),
             })
             return
-        
+
         auth_token = extract_api_key(scope)
-        
+
         token = serpapi_token_context.set(auth_token or "")
         try:
             await session_manager.handle_request(scope, receive, send)
@@ -514,7 +550,7 @@ def main(
             },
             "tools": [
                 "google_jobs_search",
-                "google_jobs_get_details", 
+                "google_jobs_get_details",
                 "google_jobs_search_by_company",
                 "google_jobs_search_remote",
                 "google_jobs_get_suggestions"
@@ -541,11 +577,11 @@ def main(
         routes=[
             # Root endpoint
             Route("/", endpoint=handle_root, methods=["GET"]),
-            
+
             # SSE routes
             Route("/sse", endpoint=handle_sse, methods=["GET"]),
             Mount("/messages", app=sse.handle_post_message),
-            
+
             # StreamableHTTP routes
             Route("/mcp", endpoint=handle_mcp_info, methods=["GET"]),
             Mount("/mcp", app=handle_streamable_http),
@@ -567,4 +603,3 @@ def main(
 
 if __name__ == "__main__":
     main()
-    

--- a/mcp_servers/google_jobs/tools/jobs.py
+++ b/mcp_servers/google_jobs/tools/jobs.py
@@ -12,13 +12,15 @@ async def search_jobs(
     salary_min: Optional[int] = None,
     company: Optional[str] = None,
     radius: Optional[int] = None,
-    start: int = 0
+    start: int = 0,
+    country: str = "us",
+    language: str = "en"
 ) -> Dict[str, Any]:
     """Search for jobs on Google Jobs."""
     logger.info(f"Executing tool: search_jobs with query: {query}")
     try:
         params = {"q": query}
-        
+
         if location:
             params["location"] = location
         if date_posted:
@@ -33,19 +35,22 @@ async def search_jobs(
             params["radius"] = radius
         if start > 0:
             params["start"] = start
-        
+
+        params["gl"] = country
+        params["hl"] = language
+
         result = await make_serpapi_request(params)
-        
+
         jobs = result.get("jobs_results", [])
         total_results = result.get("search_information", {}).get("total_results", 0)
-        
+
         if not jobs:
             return {
                 "message": f"No job listings found for query: '{query}'",
                 "total_results": 0,
                 "jobs": []
             }
-        
+
         formatted_jobs = []
         for job in jobs[:10]:  # limiting to first 10 results
             job_info = {
@@ -58,7 +63,7 @@ async def search_jobs(
                 "apply_options": [opt.get("link", "") for opt in job.get("apply_options", [])]
             }
             formatted_jobs.append(job_info)
-        
+
         response = {
             "total_results": total_results,
             "showing_results": len(formatted_jobs),
@@ -66,9 +71,9 @@ async def search_jobs(
             "location_filter": location,
             "jobs": formatted_jobs
         }
-        
+
         return response
-        
+
     except Exception as e:
         logger.exception(f"Error executing tool search_jobs: {e}")
         return {
@@ -85,18 +90,18 @@ async def get_job_details(job_id: str) -> Dict[str, Any]:
             "engine": "google_jobs_listing",
             "q": job_id
         }
-        
+
         result = await make_serpapi_request(params)
-        
+
         # Extract job details
         job_details = result.get("job", {})
-        
+
         if not job_details:
             return {
                 "error": f"No job details found for job ID: {job_id}",
                 "job_id": job_id
             }
-        
+
         formatted_details = {
             "job_id": job_id,
             "title": job_details.get("title", "N/A"),
@@ -110,9 +115,9 @@ async def get_job_details(job_id: str) -> Dict[str, Any]:
             "responsibilities": job_details.get("responsibilities", []),
             "apply_options": job_details.get("apply_options", [])
         }
-        
+
         return formatted_details
-        
+
     except Exception as e:
         logger.exception(f"Error executing tool get_job_details: {e}")
         return {
@@ -125,16 +130,18 @@ async def search_jobs_by_company(
     company_name: str,
     location: Optional[str] = None,
     employment_type: Optional[str] = None,
-    start: int = 0
+    start: int = 0,
+    country: str = "us",
+    language: str = "en"
 ) -> Dict[str, Any]:
     """Search for all job openings at a specific company."""
     logger.info(f"Executing tool: search_jobs_by_company with company: {company_name}")
     try:
         # Use company name as both query and company filter
         query = f"jobs at {company_name}"
-        
+
         params = {"q": query}
-        
+
         if location:
             params["location"] = location
         if employment_type:
@@ -143,18 +150,21 @@ async def search_jobs_by_company(
             params["company"] = company_name
         if start > 0:
             params["start"] = start
-        
+
+        params["gl"] = country
+        params["hl"] = language
+
         result = await make_serpapi_request(params)
-        
+
         jobs = result.get("jobs_results", [])
-        
+
         if not jobs:
             return {
                 "message": f"No job listings found for company: {company_name}",
                 "company": company_name,
                 "jobs": []
             }
-        
+
         formatted_jobs = []
         for job in jobs:
             job_info = {
@@ -166,16 +176,16 @@ async def search_jobs_by_company(
                 "description_snippet": job.get("description", "N/A")[:150] + "..." if job.get("description") else "N/A"
             }
             formatted_jobs.append(job_info)
-        
+
         response = {
             "company": company_name,
             "total_jobs_found": len(formatted_jobs),
             "location_filter": location,
             "jobs": formatted_jobs
         }
-        
+
         return response
-        
+
     except Exception as e:
         logger.exception(f"Error executing tool search_jobs_by_company: {e}")
         return {
@@ -189,16 +199,18 @@ async def search_remote_jobs(
     employment_type: Optional[str] = None,
     date_posted: Optional[str] = None,
     salary_min: Optional[int] = None,
-    start: int = 0
+    start: int = 0,
+    country: str = "us",
+    language: str = "en"
 ) -> Dict[str, Any]:
     """Search specifically for remote job opportunities."""
     logger.info(f"Executing tool: search_remote_jobs with query: {query}")
     try:
         # Modify query to include remote keywords
         remote_query = f"{query} remote"
-        
+
         params = {"q": remote_query, "location": "Remote"}
-        
+
         if employment_type:
             params["employment_type"] = employment_type
         if date_posted:
@@ -207,24 +219,27 @@ async def search_remote_jobs(
             params["salary_min"] = salary_min
         if start > 0:
             params["start"] = start
-        
+
+        params["gl"] = country
+        params["hl"] = language
+
         result = await make_serpapi_request(params)
-        
+
         jobs = result.get("jobs_results", [])
-        
+
         if not jobs:
             return {
                 "message": f"No remote job listings found for query: '{query}'",
                 "search_query": query,
                 "jobs": []
             }
-        
+
         remote_jobs = []
         for job in jobs:
             location = job.get("location", "").lower()
             title = job.get("title", "").lower()
             description = job.get("description", "").lower()
-            
+
             if any(remote_keyword in location or remote_keyword in title or remote_keyword in description
                    for remote_keyword in ["remote", "work from home", "anywhere", "virtual"]):
                 job_info = {
@@ -238,15 +253,15 @@ async def search_remote_jobs(
                     "description_snippet": job.get("description", "N/A")[:200] + "..." if job.get("description") else "N/A"
                 }
                 remote_jobs.append(job_info)
-        
+
         response = {
             "search_query": query,
             "remote_jobs_found": len(remote_jobs),
             "jobs": remote_jobs
         }
-        
+
         return response
-        
+
     except Exception as e:
         logger.exception(f"Error executing tool search_remote_jobs: {e}")
         return {
@@ -260,13 +275,13 @@ async def get_job_search_suggestions(query: str) -> Dict[str, Any]:
     logger.info(f"Executing tool: get_job_search_suggestions with query: {query}")
     try:
         params = {"q": query}
-        
+
         result = await make_serpapi_request(params)
-        
+
         # Extract job titles and companies for suggestions
         jobs = result.get("jobs_results", [])
         related_searches = result.get("related_searches", [])
-        
+
         suggestions = {
             "original_query": query,
             "related_searches": [search.get("query", "") for search in related_searches],
@@ -274,9 +289,9 @@ async def get_job_search_suggestions(query: str) -> Dict[str, Any]:
             "companies_hiring": list(set([job.get("company_name", "") for job in jobs[:10] if job.get("company_name")])),
             "common_locations": list(set([job.get("location", "") for job in jobs[:10] if job.get("location")]))
         }
-        
+
         return suggestions
-        
+
     except Exception as e:
         logger.exception(f"Error executing tool get_job_search_suggestions: {e}")
         return {
@@ -284,4 +299,3 @@ async def get_job_search_suggestions(query: str) -> Dict[str, Any]:
             "query": query,
             "exception": str(e)
         }
-        


### PR DESCRIPTION
## Description
Currently, there are no region or language parameters, making it virtually impossible to search outside of North America.
Added country and language parameters to the Google Jobs MCP server search tools. This enables job searches for specific countries and languages, improving localization support for international job searches.

## Motivation
The Google Jobs API supports country and language parameters to filter job search results by geographic location and language. Adding these parameters allows users to:
- Search for jobs in specific countries
- Get results in their preferred language
- Improve search relevance for international users

## Implementation Details
- Added `country` parameter to specify the country code (e.g., "US", "JP", "GB")
- Added `language` parameter to specify the language code (e.g., "en", "ja", "fr")
- Both parameters are optional and maintain backward compatibility
- Parameters are passed through to the Google Jobs API

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
<!-- e.g. Fixes #123 or Related to #456 -->

## Type of change
- [x] New MCP feature (non-breaking change which adds functionality)

## How has this been tested?
- Tested locally with various country and language combinations
- Verified that searches with country and language parameters work correctly
- Confirmed backward compatibility (existing searches without parameters still work)

## Breaking Changes
None - This is a non-breaking change. The new parameters are optional and default behavior is unchanged.

## Documentation
- [ ] I have made corresponding changes to the documentation
  - Note: Documentation update may be needed if this affects the public API documentation

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Note: Tests should be added following the pattern used in other MCP servers (e.g., `openrouter/test_server.py`)
- [ ] New and existing tests pass locally with my changes