### PR TITLE
Fix phone number assignment in Attio MCP server

### DIFF
--- a/mcp_servers/attio/index.ts
+++ b/mcp_servers/attio/index.ts
@@ -155,9 +155,7 @@ class AttioClient {
         if (data.name) { recordData.name = data.name; }
         if (data.email_addresses) { recordData.email_addresses = data.email_addresses; }
         if (data.phone_numbers) {
-            for (const phoneNumber of data.phone_numbers) {
-                recordData.phone_numbers.push({ original_phone_number: phoneNumber });
-            }
+            recordData.phone_numbers = data.phone_numbers.map(phoneNumber => ({ original_phone_number: phoneNumber }));
         }
         if (data.job_title) { recordData.job_title = data.job_title; }
         if (data.description) { recordData.description = data.description; }
@@ -206,9 +204,7 @@ class AttioClient {
         if (data.name) { recordData.name = data.name; }
         if (data.email_addresses) { recordData.email_addresses = data.email_addresses; }
         if (data.phone_numbers) {
-            for (const phoneNumber of data.phone_numbers) {
-                recordData.phone_numbers.push({ original_phone_number: phoneNumber });
-            }
+            recordData.phone_numbers = data.phone_numbers.map(phoneNumber => ({ original_phone_number: phoneNumber }));
         }
         if (data.job_title) { recordData.job_title = data.job_title; }
         if (data.description) { recordData.description = data.description; }


### PR DESCRIPTION
## Problem
When creating or updating person records with phone numbers, the code was using `push()` on an uninitialized array, which could cause errors or unexpected behavior.

## Solution
Replaced the `for` loop with `Array.map()` to properly transform the phone number strings into objects with the `original_phone_number` property. This ensures `recordData.phone_numbers` is assigned a new array rather than attempting to push to a potentially undefined array.

## Changes
- Refactored phone number handling in `createPerson()` method (line ~158)
- Refactored phone number handling in `updatePerson()` method (line ~207)

Both methods now use a functional programming approach that's more concise and safer.

## Testing
- [x] Verify person creation with phone numbers works correctly
- [x] Verify person updates with phone numbers works correctly
- [ ] Confirm no regression in other person attributes