### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/mcp_servers/calendly/server.py
+++ b/mcp_servers/calendly/server.py
@@ -70,7 +70,8 @@ def main(
                 inputSchema={
                     "type": "object",
                     "properties": {}
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get User Info", readOnlyHint=True)
             ),
             types.Tool(
                 name="calendly_list_events",
@@ -90,7 +91,8 @@ def main(
                             "maximum": 100
                         }
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="List Events", readOnlyHint=True)
             ),
             types.Tool(
                 name="calendly_get_event_details",
@@ -104,7 +106,8 @@ def main(
                             "description": "The UUID of the event to retrieve details for."
                         }
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Event Details", readOnlyHint=True)
             ),
             types.Tool(
                 name="calendly_list_event_types",
@@ -124,7 +127,8 @@ def main(
                             "maximum": 100
                         }
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="List Event Types", readOnlyHint=True)
             ),
             types.Tool(
                 name="calendly_list_availability_schedules",
@@ -143,7 +147,8 @@ def main(
                             "maximum": 100
                         }
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="List Availability Schedules", readOnlyHint=True)
             ),
             types.Tool(
                 name="calendly_list_event_invitees",
@@ -172,7 +177,8 @@ def main(
                             "enum": ["active", "canceled"]
                         }
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="List Event Invitees", readOnlyHint=True)
             ),
         ]
 

--- a/mcp_servers/figma/server.py
+++ b/mcp_servers/figma/server.py
@@ -67,12 +67,14 @@ async def run_server(log_level: str = "INFO"):
             types.Tool(
                 name="figma_test_connection",
                 description="Test Figma Connection - verify API authentication is working correctly.",
-                inputSchema={"type": "object", "properties": {}}
+                inputSchema={"type": "object", "properties": {}},
+                annotations=types.ToolAnnotations(title="Test Connection", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_current_user",
                 description="Get Current User - retrieve information about the authenticated user.",
-                inputSchema={"type": "object", "properties": {}}
+                inputSchema={"type": "object", "properties": {}},
+                annotations=types.ToolAnnotations(title="Get Current User", readOnlyHint=True)
             ),
             
             # File management tools
@@ -91,7 +93,8 @@ async def run_server(log_level: str = "INFO"):
                         "plugin_data": {"type": "string", "description": "Plugin data to include"},
                         "branch_data": {"type": "boolean", "description": "Whether to include branch data"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get File", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_file_nodes",
@@ -107,7 +110,8 @@ async def run_server(log_level: str = "INFO"):
                         "geometry": {"type": "string", "enum": ["paths", "no_geometry"], "description": "Whether to include geometry data"},
                         "plugin_data": {"type": "string", "description": "Plugin data to include"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get File Nodes", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_file_images",
@@ -125,7 +129,8 @@ async def run_server(log_level: str = "INFO"):
                         "use_absolute_bounds": {"type": "boolean", "description": "Use absolute bounds for export"},
                         "version": {"type": "string", "description": "Specific version to export"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get File Images", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_file_versions",
@@ -136,7 +141,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get File Versions", readOnlyHint=True)
             ),
             
             # Project management tools
@@ -149,7 +155,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "team_id": {"type": "string", "description": "The team ID (from Figma team URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Team Projects", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_project_files",
@@ -161,7 +168,8 @@ async def run_server(log_level: str = "INFO"):
                         "project_id": {"type": "string", "description": "The project ID"},
                         "branch_data": {"type": "boolean", "description": "Whether to include branch data"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Project Files", readOnlyHint=True)
             ),
             
             # Comment management tools
@@ -175,7 +183,8 @@ async def run_server(log_level: str = "INFO"):
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"},
                         "as_md": {"type": "boolean", "description": "Return comments as markdown"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get File Comments", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_post_file_comment",
@@ -189,7 +198,8 @@ async def run_server(log_level: str = "INFO"):
                         "client_meta": {"type": "object", "description": "Client metadata including x, y coordinates and node_id"},
                         "comment_id": {"type": "string", "description": "Parent comment ID for replies"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Post Comment", destructiveHint=True)
             ),
             types.Tool(
                 name="figma_delete_comment",
@@ -200,7 +210,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "comment_id": {"type": "string", "description": "The comment ID to delete"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Delete Comment", destructiveHint=True)
             ),
             
             # Variables (Design Tokens) management tools
@@ -213,7 +224,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Local Variables", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_get_published_variables",
@@ -224,7 +236,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Published Variables", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_post_variables",
@@ -237,7 +250,8 @@ async def run_server(log_level: str = "INFO"):
                         "variableCollections": {"type": "array", "description": "Array of variable collections to create/update"},
                         "variables": {"type": "array", "description": "Array of variables to create/update"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Create/Update Variables", destructiveHint=True)
             ),
             
             # Dev Resources management tools
@@ -251,7 +265,8 @@ async def run_server(log_level: str = "INFO"):
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"},
                         "node_id": {"type": "string", "description": "Filter by specific node ID"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Dev Resources", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_post_dev_resources",
@@ -263,7 +278,8 @@ async def run_server(log_level: str = "INFO"):
                         "file_key": {"type": "string", "description": "The file key (from Figma URL)"},
                         "dev_resources": {"type": "array", "description": "Array of dev resources to create"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Create Dev Resources", destructiveHint=True)
             ),
             types.Tool(
                 name="figma_put_dev_resource",
@@ -276,7 +292,8 @@ async def run_server(log_level: str = "INFO"):
                         "name": {"type": "string", "description": "New name for the dev resource"},
                         "url": {"type": "string", "description": "New URL for the dev resource"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Update Dev Resource", destructiveHint=True)
             ),
             types.Tool(
                 name="figma_delete_dev_resource",
@@ -287,7 +304,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "dev_resource_id": {"type": "string", "description": "The dev resource ID to delete"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Delete Dev Resource", destructiveHint=True)
             ),
             
             # Webhook management tools
@@ -300,7 +318,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "team_id": {"type": "string", "description": "The team ID (from Figma team URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Team Webhooks", readOnlyHint=True)
             ),
             types.Tool(
                 name="figma_post_webhook",
@@ -315,7 +334,8 @@ async def run_server(log_level: str = "INFO"):
                         "passcode": {"type": "string", "description": "Passcode for webhook verification"},
                         "description": {"type": "string", "description": "Description of the webhook"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Create Webhook", destructiveHint=True)
             ),
             types.Tool(
                 name="figma_put_webhook",
@@ -330,7 +350,8 @@ async def run_server(log_level: str = "INFO"):
                         "passcode": {"type": "string", "description": "Passcode for webhook verification"},
                         "description": {"type": "string", "description": "Description of the webhook"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Update Webhook", destructiveHint=True)
             ),
             types.Tool(
                 name="figma_delete_webhook",
@@ -341,7 +362,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "webhook_id": {"type": "string", "description": "The webhook ID to delete"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Delete Webhook", destructiveHint=True)
             ),
             
             # Library Analytics tools
@@ -354,7 +376,8 @@ async def run_server(log_level: str = "INFO"):
                     "properties": {
                         "file_key": {"type": "string", "description": "The file key of a published library (from Figma URL)"}
                     }
-                }
+                },
+                annotations=types.ToolAnnotations(title="Get Library Analytics", readOnlyHint=True)
             ),
         ]
         

--- a/mcp_servers/intercom/src/tools/definitions/articleTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/articleTools.ts
@@ -6,6 +6,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 const LIST_ARTICLES_TOOL: Tool = {
   name: 'intercom_list_articles',
   description: 'List all articles in your Help Center with pagination support.',
+  annotations: {
+    title: 'List Articles',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -31,6 +35,10 @@ const LIST_ARTICLES_TOOL: Tool = {
 const GET_ARTICLE_TOOL: Tool = {
   name: 'intercom_get_article',
   description: 'Retrieve a specific article by its ID.',
+  annotations: {
+    title: 'Get Article',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -50,6 +58,10 @@ const GET_ARTICLE_TOOL: Tool = {
 const CREATE_ARTICLE_TOOL: Tool = {
   name: 'intercom_create_article',
   description: 'Create a new article in your Help Center.',
+  annotations: {
+    title: 'Create Article',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -149,6 +161,10 @@ const CREATE_ARTICLE_TOOL: Tool = {
 const UPDATE_ARTICLE_TOOL: Tool = {
   name: 'intercom_update_article',
   description: 'Update an existing article in your Help Center.',
+  annotations: {
+    title: 'Update Article',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -242,6 +258,10 @@ const UPDATE_ARTICLE_TOOL: Tool = {
 const DELETE_ARTICLE_TOOL: Tool = {
   name: 'intercom_delete_article',
   description: 'Delete a single article from your Help Center.',
+  annotations: {
+    title: 'Delete Article',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -261,6 +281,10 @@ const DELETE_ARTICLE_TOOL: Tool = {
 const SEARCH_ARTICLES_TOOL: Tool = {
   name: 'intercom_search_articles',
   description: 'Search articles in your Help Center using query filters.',
+  annotations: {
+    title: 'Search Articles',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -313,6 +337,10 @@ const SEARCH_ARTICLES_TOOL: Tool = {
 const LIST_COLLECTIONS_TOOL: Tool = {
   name: 'intercom_list_collections',
   description: 'List all Help Center collections with pagination support.',
+  annotations: {
+    title: 'List Collections',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -338,6 +366,10 @@ const LIST_COLLECTIONS_TOOL: Tool = {
 const GET_COLLECTION_TOOL: Tool = {
   name: 'intercom_get_collection',
   description: 'Retrieve a specific Help Center collection by its ID.',
+  annotations: {
+    title: 'Get Collection',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -357,6 +389,10 @@ const GET_COLLECTION_TOOL: Tool = {
 const CREATE_COLLECTION_TOOL: Tool = {
   name: 'intercom_create_collection',
   description: 'Create a new Help Center collection.',
+  annotations: {
+    title: 'Create Collection',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -416,6 +452,10 @@ const CREATE_COLLECTION_TOOL: Tool = {
 const UPDATE_COLLECTION_TOOL: Tool = {
   name: 'intercom_update_collection',
   description: 'Update an existing Help Center collection.',
+  annotations: {
+    title: 'Update Collection',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -473,6 +513,10 @@ const UPDATE_COLLECTION_TOOL: Tool = {
 const DELETE_COLLECTION_TOOL: Tool = {
   name: 'intercom_delete_collection',
   description: 'Delete a single Help Center collection.',
+  annotations: {
+    title: 'Delete Collection',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/companyTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/companyTools.ts
@@ -6,6 +6,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 const LIST_COMPANIES_TOOL: Tool = {
   name: 'intercom_list_companies',
   description: 'List all companies in your Intercom workspace with pagination support.',
+  annotations: {
+    title: 'List Companies',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -37,6 +41,10 @@ const LIST_COMPANIES_TOOL: Tool = {
 const GET_COMPANY_TOOL: Tool = {
   name: 'intercom_get_company',
   description: 'Retrieve a specific company by their Intercom ID.',
+  annotations: {
+    title: 'Get Company',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -56,6 +64,10 @@ const GET_COMPANY_TOOL: Tool = {
 const CREATE_COMPANY_TOOL: Tool = {
   name: 'intercom_create_company',
   description: 'Create a new company in Intercom workspace.',
+  annotations: {
+    title: 'Create Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -133,6 +145,10 @@ const CREATE_COMPANY_TOOL: Tool = {
 const UPDATE_COMPANY_TOOL: Tool = {
   name: 'intercom_update_company',
   description: 'Update an existing company in Intercom workspace.',
+  annotations: {
+    title: 'Update Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -201,6 +217,10 @@ const UPDATE_COMPANY_TOOL: Tool = {
 const DELETE_COMPANY_TOOL: Tool = {
   name: 'intercom_delete_company',
   description: 'Delete a single company from Intercom workspace.',
+  annotations: {
+    title: 'Delete Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -220,6 +240,10 @@ const DELETE_COMPANY_TOOL: Tool = {
 const FIND_COMPANY_TOOL: Tool = {
   name: 'intercom_find_company',
   description: 'Find a company using your own company_id (external identifier).',
+  annotations: {
+    title: 'Find Company',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -239,6 +263,10 @@ const FIND_COMPANY_TOOL: Tool = {
 const LIST_COMPANY_USERS_TOOL: Tool = {
   name: 'intercom_list_company_users',
   description: 'List all users that belong to a specific company.',
+  annotations: {
+    title: 'List Company Users',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -258,6 +286,10 @@ const LIST_COMPANY_USERS_TOOL: Tool = {
 const ATTACH_CONTACT_TO_COMPANY_TOOL: Tool = {
   name: 'intercom_attach_contact_to_company',
   description: 'Attach a contact to a company.',
+  annotations: {
+    title: 'Attach Contact to Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -282,6 +314,10 @@ const ATTACH_CONTACT_TO_COMPANY_TOOL: Tool = {
 const DETACH_CONTACT_FROM_COMPANY_TOOL: Tool = {
   name: 'intercom_detach_contact_from_company',
   description: 'Detach a contact from a company.',
+  annotations: {
+    title: 'Detach Contact from Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -306,6 +342,10 @@ const DETACH_CONTACT_FROM_COMPANY_TOOL: Tool = {
 const LIST_COMPANY_SEGMENTS_TOOL: Tool = {
   name: 'intercom_list_company_segments',
   description: 'List all segments that a specific company belongs to.',
+  annotations: {
+    title: 'List Company Segments',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -325,6 +365,10 @@ const LIST_COMPANY_SEGMENTS_TOOL: Tool = {
 const LIST_COMPANY_TAGS_TOOL: Tool = {
   name: 'intercom_list_company_tags',
   description: 'List all tags attached to a specific company.',
+  annotations: {
+    title: 'List Company Tags',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -344,6 +388,10 @@ const LIST_COMPANY_TAGS_TOOL: Tool = {
 const TAG_COMPANY_TOOL: Tool = {
   name: 'intercom_tag_company',
   description: 'Add a tag to a specific company.',
+  annotations: {
+    title: 'Tag Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -383,6 +431,10 @@ const TAG_COMPANY_TOOL: Tool = {
 const UNTAG_COMPANY_TOOL: Tool = {
   name: 'intercom_untag_company',
   description: 'Remove a tag from a specific company.',
+  annotations: {
+    title: 'Untag Company',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/contactTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/contactTools.ts
@@ -7,6 +7,10 @@ const LIST_CONTACTS_TOOL: Tool = {
   name: 'intercom_list_contacts',
   description:
     'List all contacts (users or leads) in your Intercom workspace with pagination support.',
+  annotations: {
+    title: 'List Contacts',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -32,6 +36,10 @@ const LIST_CONTACTS_TOOL: Tool = {
 const GET_CONTACT_TOOL: Tool = {
   name: 'intercom_get_contact',
   description: 'Retrieve a specific contact by their Intercom ID.',
+  annotations: {
+    title: 'Get Contact',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -51,6 +59,10 @@ const GET_CONTACT_TOOL: Tool = {
 const CREATE_CONTACT_TOOL: Tool = {
   name: 'intercom_create_contact',
   description: 'Create a new contact in Intercom workspace.',
+  annotations: {
+    title: 'Create Contact',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -144,6 +156,10 @@ const CREATE_CONTACT_TOOL: Tool = {
 const UPDATE_CONTACT_TOOL: Tool = {
   name: 'intercom_update_contact',
   description: 'Update an existing contact in Intercom workspace.',
+  annotations: {
+    title: 'Update Contact',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -230,6 +246,10 @@ const SEARCH_CONTACTS_TOOL: Tool = {
   name: 'intercom_search_contacts',
   description:
     'Search contacts using query filters and operators with advanced search capabilities.',
+  annotations: {
+    title: 'Search Contacts',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -333,6 +353,10 @@ const SEARCH_CONTACTS_TOOL: Tool = {
 const DELETE_CONTACT_TOOL: Tool = {
   name: 'intercom_delete_contact',
   description: 'Delete a single contact from Intercom workspace.',
+  annotations: {
+    title: 'Delete Contact',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -352,6 +376,10 @@ const DELETE_CONTACT_TOOL: Tool = {
 const MERGE_CONTACT_TOOL: Tool = {
   name: 'intercom_merge_contact',
   description: 'Merge a contact with a role of lead into a contact with a role of user.',
+  annotations: {
+    title: 'Merge Contact',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -376,6 +404,10 @@ const MERGE_CONTACT_TOOL: Tool = {
 const LIST_CONTACT_NOTES_TOOL: Tool = {
   name: 'intercom_list_contact_notes',
   description: 'List all notes attached to a specific contact.',
+  annotations: {
+    title: 'List Contact Notes',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -395,6 +427,10 @@ const LIST_CONTACT_NOTES_TOOL: Tool = {
 const CREATE_CONTACT_NOTE_TOOL: Tool = {
   name: 'intercom_create_contact_note',
   description: 'Add a note to a specific contact.',
+  annotations: {
+    title: 'Create Contact Note',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -429,6 +465,10 @@ const CREATE_CONTACT_NOTE_TOOL: Tool = {
 const LIST_CONTACT_TAGS_TOOL: Tool = {
   name: 'intercom_list_contact_tags',
   description: 'List all tags attached to a specific contact.',
+  annotations: {
+    title: 'List Contact Tags',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -448,6 +488,10 @@ const LIST_CONTACT_TAGS_TOOL: Tool = {
 const ADD_CONTACT_TAG_TOOL: Tool = {
   name: 'intercom_add_contact_tag',
   description: 'Add a tag to a specific contact.',
+  annotations: {
+    title: 'Add Contact Tag',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -472,6 +516,10 @@ const ADD_CONTACT_TAG_TOOL: Tool = {
 const REMOVE_CONTACT_TAG_TOOL: Tool = {
   name: 'intercom_remove_contact_tag',
   description: 'Remove a tag from a specific contact.',
+  annotations: {
+    title: 'Remove Contact Tag',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/conversationTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/conversationTools.ts
@@ -6,6 +6,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 const LIST_CONVERSATIONS_TOOL: Tool = {
   name: 'intercom_list_conversations',
   description: 'List all conversations in your Intercom workspace with pagination support.',
+  annotations: {
+    title: 'List Conversations',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -36,6 +40,10 @@ const LIST_CONVERSATIONS_TOOL: Tool = {
 const GET_CONVERSATION_TOOL: Tool = {
   name: 'intercom_get_conversation',
   description: 'Retrieve a specific conversation by its ID with all conversation parts.',
+  annotations: {
+    title: 'Get Conversation',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -61,6 +69,10 @@ const CREATE_CONVERSATION_TOOL: Tool = {
   name: 'intercom_create_conversation',
   description:
     'Create a conversation that has been initiated by a contact (user or lead). The conversation can be an in-app message only.',
+  annotations: {
+    title: 'Create Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -108,6 +120,10 @@ const CREATE_CONVERSATION_TOOL: Tool = {
 const UPDATE_CONVERSATION_TOOL: Tool = {
   name: 'intercom_update_conversation',
   description: 'Update an existing conversation including custom attributes and read status.',
+  annotations: {
+    title: 'Update Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -147,6 +163,10 @@ const UPDATE_CONVERSATION_TOOL: Tool = {
 const DELETE_CONVERSATION_TOOL: Tool = {
   name: 'intercom_delete_conversation',
   description: 'Delete a single conversation from Intercom workspace.',
+  annotations: {
+    title: 'Delete Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -166,6 +186,10 @@ const SEARCH_CONVERSATIONS_TOOL: Tool = {
   name: 'intercom_search_conversations',
   description:
     'Search conversations using query filters and operators with advanced search capabilities.',
+  annotations: {
+    title: 'Search Conversations',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -270,6 +294,10 @@ const REPLY_CONVERSATION_TOOL: Tool = {
   name: 'intercom_reply_conversation',
   description:
     'Reply to a conversation with a message from an admin or on behalf of a contact, or with a note for admins.',
+  annotations: {
+    title: 'Reply to Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -322,6 +350,10 @@ const REPLY_CONVERSATION_TOOL: Tool = {
 const MANAGE_CONVERSATION_TOOL: Tool = {
   name: 'intercom_manage_conversation',
   description: 'Perform management actions on a conversation: close, snooze, open, or assign.',
+  annotations: {
+    title: 'Manage Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -374,6 +406,10 @@ const ATTACH_CONTACT_TO_CONVERSATION_TOOL: Tool = {
   name: 'intercom_attach_contact_to_conversation',
   description:
     'Add participants who are contacts to a conversation, on behalf of either another contact or an admin.',
+  annotations: {
+    title: 'Attach Contact to Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -410,6 +446,10 @@ const ATTACH_CONTACT_TO_CONVERSATION_TOOL: Tool = {
 const DETACH_CONTACT_FROM_CONVERSATION_TOOL: Tool = {
   name: 'intercom_detach_contact_from_conversation',
   description: 'Remove a contact from a group conversation.',
+  annotations: {
+    title: 'Detach Contact from Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -451,6 +491,10 @@ const DETACH_CONTACT_FROM_CONVERSATION_TOOL: Tool = {
 const REDACT_CONVERSATION_TOOL: Tool = {
   name: 'intercom_redact_conversation',
   description: 'Redact a conversation part or the source message of a conversation.',
+  annotations: {
+    title: 'Redact Conversation',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -486,6 +530,10 @@ const REDACT_CONVERSATION_TOOL: Tool = {
 const CONVERT_CONVERSATION_TO_TICKET_TOOL: Tool = {
   name: 'intercom_convert_conversation_to_ticket',
   description: 'Convert a conversation to a ticket.',
+  annotations: {
+    title: 'Convert to Ticket',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/messageTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/messageTools.ts
@@ -7,6 +7,10 @@ const CREATE_MESSAGE_TOOL: Tool = {
   name: 'intercom_create_message',
   description:
     'Create a message that has been initiated by an admin. The conversation can be an in-app message or an email.',
+  annotations: {
+    title: 'Create Message',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -108,6 +112,10 @@ const CREATE_MESSAGE_TOOL: Tool = {
 const LIST_MESSAGES_TOOL: Tool = {
   name: 'intercom_list_messages',
   description: 'List all messages sent from your workspace with pagination support.',
+  annotations: {
+    title: 'List Messages',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -133,6 +141,10 @@ const LIST_MESSAGES_TOOL: Tool = {
 const GET_MESSAGE_TOOL: Tool = {
   name: 'intercom_get_message',
   description: 'Retrieve a specific message by its ID.',
+  annotations: {
+    title: 'Get Message',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -152,6 +164,10 @@ const GET_MESSAGE_TOOL: Tool = {
 const CREATE_NOTE_TOOL: Tool = {
   name: 'intercom_create_note',
   description: 'Add a note to a specific contact.',
+  annotations: {
+    title: 'Create Note',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -182,6 +198,10 @@ const CREATE_NOTE_TOOL: Tool = {
 const LIST_NOTES_TOOL: Tool = {
   name: 'intercom_list_notes',
   description: 'List all notes attached to a specific contact.',
+  annotations: {
+    title: 'List Notes',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -212,6 +232,10 @@ const LIST_NOTES_TOOL: Tool = {
 const GET_NOTE_TOOL: Tool = {
   name: 'intercom_get_note',
   description: 'Retrieve a specific note by its ID.',
+  annotations: {
+    title: 'Get Note',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -232,6 +256,10 @@ const SEND_USER_MESSAGE_TOOL: Tool = {
   name: 'intercom_send_user_message',
   description:
     'Create a conversation that has been initiated by a contact (user or lead). The conversation can be an in-app message only.',
+  annotations: {
+    title: 'Send User Message',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/tagTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/tagTools.ts
@@ -6,6 +6,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 const LIST_TAGS_TOOL: Tool = {
   name: 'intercom_list_tags',
   description: 'List all tags in your Intercom workspace.',
+  annotations: {
+    title: 'List Tags',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -19,6 +23,10 @@ const LIST_TAGS_TOOL: Tool = {
 const GET_TAG_TOOL: Tool = {
   name: 'intercom_get_tag',
   description: 'Retrieve a specific tag by its ID.',
+  annotations: {
+    title: 'Get Tag',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -38,6 +46,10 @@ const GET_TAG_TOOL: Tool = {
 const CREATE_OR_UPDATE_TAG_TOOL: Tool = {
   name: 'intercom_create_or_update_tag',
   description: 'Create a new tag or update an existing tag by name or ID.',
+  annotations: {
+    title: 'Create or Update Tag',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -64,6 +76,10 @@ const TAG_COMPANIES_TOOL: Tool = {
   name: 'intercom_tag_companies',
   description:
     "Tag a single company or a list of companies. If the tag doesn't exist, a new one will be created automatically.",
+  annotations: {
+    title: 'Tag Companies',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -103,6 +119,10 @@ const TAG_COMPANIES_TOOL: Tool = {
 const UNTAG_COMPANIES_TOOL: Tool = {
   name: 'intercom_untag_companies',
   description: 'Remove a tag from a single company or a list of companies.',
+  annotations: {
+    title: 'Untag Companies',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -149,6 +169,10 @@ const TAG_USERS_TOOL: Tool = {
   name: 'intercom_tag_users',
   description:
     "Tag a list of users/contacts. If the tag doesn't exist, a new one will be created automatically.",
+  annotations: {
+    title: 'Tag Users',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -184,6 +208,10 @@ const DELETE_TAG_TOOL: Tool = {
   name: 'intercom_delete_tag',
   description:
     'Delete a tag from your workspace. Note: tags with dependent objects (like segments) cannot be deleted.',
+  annotations: {
+    title: 'Delete Tag',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/intercom/src/tools/definitions/teamTools.ts
+++ b/mcp_servers/intercom/src/tools/definitions/teamTools.ts
@@ -6,6 +6,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 const LIST_TEAMS_TOOL: Tool = {
   name: 'intercom_list_teams',
   description: 'List all teams in your Intercom workspace.',
+  annotations: {
+    title: 'List Teams',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -20,6 +24,10 @@ const GET_TEAM_TOOL: Tool = {
   name: 'intercom_get_team',
   description:
     'Retrieve a specific team by its ID, containing an array of admins that belong to this team.',
+  annotations: {
+    title: 'Get Team',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -39,6 +47,10 @@ const GET_TEAM_TOOL: Tool = {
 const LIST_ADMINS_TOOL: Tool = {
   name: 'intercom_list_admins',
   description: 'List all admins (teammates) in your Intercom workspace.',
+  annotations: {
+    title: 'List Admins',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -52,6 +64,10 @@ const LIST_ADMINS_TOOL: Tool = {
 const GET_ADMIN_TOOL: Tool = {
   name: 'intercom_get_admin',
   description: 'Retrieve the details of a single admin (teammate).',
+  annotations: {
+    title: 'Get Admin',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -72,6 +88,10 @@ const GET_CURRENT_ADMIN_TOOL: Tool = {
   name: 'intercom_get_current_admin',
   description:
     'Identify the currently authorized admin along with the embedded app object (workspace).',
+  annotations: {
+    title: 'Get Current Admin',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {},
@@ -85,6 +105,10 @@ const GET_CURRENT_ADMIN_TOOL: Tool = {
 const SET_ADMIN_AWAY_TOOL: Tool = {
   name: 'intercom_set_admin_away',
   description: 'Set an admin as away for the Inbox, with options for reassigning conversations.',
+  annotations: {
+    title: 'Set Admin Away',
+    destructiveHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {
@@ -116,6 +140,10 @@ const SET_ADMIN_AWAY_TOOL: Tool = {
 const LIST_ADMIN_ACTIVITY_LOGS_TOOL: Tool = {
   name: 'intercom_list_admin_activity_logs',
   description: 'Get a log of activities by all admins in an app within a specified timeframe.',
+  annotations: {
+    title: 'List Admin Activity Logs',
+    readOnlyHint: true,
+  },
   inputSchema: {
     type: 'object',
     properties: {

--- a/mcp_servers/msteams/server.py
+++ b/mcp_servers/msteams/server.py
@@ -68,13 +68,12 @@ def get_all_tools() -> list[types.Tool]:
     return [
         types.Tool(
             name="msteams_list_all_teams",
-            title="List All Teams",
             description="Lists all Microsoft Teams in the organization.",
             inputSchema={"type": "object", "properties": {}},
+            annotations=types.ToolAnnotations(title="List All Teams", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_get_team",
-            title="Get Team",
             description="Gets the details of a specific team by its ID.",
             inputSchema={
                 "type": "object",
@@ -83,10 +82,10 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["team_id"],
             },
+            annotations=types.ToolAnnotations(title="Get Team", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_list_channels",
-            title="List Team Channels",
             description="Lists the channels within a specific team.",
             inputSchema={
                 "type": "object",
@@ -95,10 +94,10 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["team_id"],
             },
+            annotations=types.ToolAnnotations(title="List Team Channels", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_create_channel",
-            title="Create Team Channel",
             description="Creates a new channel within a specific team.",
             inputSchema={
                 "type": "object",
@@ -109,10 +108,10 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["team_id", "display_name"],
             },
+            annotations=types.ToolAnnotations(title="Create Team Channel", destructiveHint=True),
         ),
         types.Tool(
             name="msteams_send_channel_message",
-            title="Send Channel Message",
             description="Sends a message to a specific channel in a Team.",
             inputSchema={
                 "type": "object",
@@ -123,16 +122,16 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["team_id", "channel_id", "message"],
             },
+            annotations=types.ToolAnnotations(title="Send Channel Message", destructiveHint=True),
         ),
         types.Tool(
             name="msteams_list_chats",
-            title="List Chats",
             description="Lists all 1-on-1 and group chats the application has access to.",
             inputSchema={"type": "object", "properties": {}},
+            annotations=types.ToolAnnotations(title="List Chats", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_send_chat_message",
-            title="Send Chat Message",
             description="Sends a message to a specific chat.",
             inputSchema={
                 "type": "object",
@@ -142,16 +141,16 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["chat_id", "message"],
             },
+            annotations=types.ToolAnnotations(title="Send Chat Message", destructiveHint=True),
         ),
         types.Tool(
             name="msteams_list_users",
-            title="List Users",
             description="Lists all users in the organization.",
             inputSchema={"type": "object", "properties": {}},
+            annotations=types.ToolAnnotations(title="List Users", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_get_user",
-            title="Get User",
             description="Gets a specific user by their ID or userPrincipalName.",
             inputSchema={
                 "type": "object",
@@ -160,10 +159,10 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["user_id"],
             },
+            annotations=types.ToolAnnotations(title="Get User", readOnlyHint=True),
         ),
         types.Tool(
             name="msteams_create_online_meeting",
-            title="Create Online Meeting",
             description="Schedules a new online Teams meeting for a given user.",
             inputSchema={
                 "type": "object",
@@ -175,10 +174,10 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["user_id", "subject", "start_datetime", "end_datetime"],
             },
+            annotations=types.ToolAnnotations(title="Create Online Meeting", destructiveHint=True),
         ),
         types.Tool(
             name="msteams_list_online_meetings",
-            title="List Online Meetings",
             description="Lists all online meetings for a specific user.",
             inputSchema={
                 "type": "object",
@@ -187,6 +186,7 @@ def get_all_tools() -> list[types.Tool]:
                 },
                 "required": ["user_id"],
             },
+            annotations=types.ToolAnnotations(title="List Online Meetings", readOnlyHint=True),
         ),
     ]
 

--- a/mcp_servers/perplexity_ai/server.py
+++ b/mcp_servers/perplexity_ai/server.py
@@ -92,6 +92,7 @@ def main(
                     },
                     "required": ["messages"],
                 },
+                annotations=types.ToolAnnotations(title="Perplexity Search", readOnlyHint=True),
             ),
             # Perplexity Reason Tool
             types.Tool(
@@ -125,6 +126,7 @@ def main(
                     },
                     "required": ["messages"],
                 },
+                annotations=types.ToolAnnotations(title="Perplexity Reason", readOnlyHint=True),
             ),
         ]
 

--- a/mcp_servers/trello/server.py
+++ b/mcp_servers/trello/server.py
@@ -43,7 +43,8 @@ def get_all_tools() -> list[types.Tool]:
         types.Tool(
             name="trello_get_my_boards",
             description="Fetches all boards that the user is a member of.",
-            inputSchema={"type": "object", "properties": {}}
+            inputSchema={"type": "object", "properties": {}},
+            annotations=types.ToolAnnotations(title="Get My Boards", readOnlyHint=True)
         ),
         types.Tool(
             name="trello_create_board",
@@ -61,7 +62,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["name"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Create Board", destructiveHint=True)
         ),
         types.Tool(
             name="trello_get_board_lists",
@@ -75,7 +77,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["board_id"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Get Board Lists", readOnlyHint=True)
         ),
         types.Tool(
             name="trello_get_list_cards",
@@ -89,7 +92,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["list_id"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Get List Cards", readOnlyHint=True)
         ),
         types.Tool(
             name="trello_create_card",
@@ -111,7 +115,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["idList", "name"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Create Card", destructiveHint=True)
         ),
         types.Tool(
             name="trello_update_card",
@@ -137,7 +142,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["card_id"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Update Card", destructiveHint=True)
         ),
         types.Tool(
             name="trello_delete_card",
@@ -151,7 +157,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["card_id"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Delete Card", destructiveHint=True)
         ),
         types.Tool(
             name="trello_create_checklist",
@@ -169,7 +176,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["idCard", "name"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Create Checklist", destructiveHint=True)
         ),
         types.Tool(
             name="trello_add_item_to_checklist",
@@ -191,7 +199,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["idChecklist", "name"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Add Checklist Item", destructiveHint=True)
         ),
         types.Tool(
             name="trello_update_checklist_item_state",
@@ -214,7 +223,8 @@ def get_all_tools() -> list[types.Tool]:
                     }
                 },
                 "required": ["idCard", "idCheckItem", "state"]
-            }
+            },
+            annotations=types.ToolAnnotations(title="Update Checklist Item", destructiveHint=True)
         ),
     ]
 


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`) to 121 tools across 6 MCP servers to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Servers Updated

| Server | Tools Annotated |
|--------|-----------------|
| Figma | 23 |
| Trello | 10 |
| Calendly | 6 |
| Perplexity AI | 2 |
| MS Teams | 11 |
| Intercom | 69 |
| **Total** | **121** |

## Changes

- Added `readOnlyHint: true` to read-only tools (queries, fetches)
- Added `destructiveHint: true` to tools that create/update/delete data
- Added `title` annotations for human-readable display

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- `readOnlyHint` tells the LLM a tool is safe to call without side effects
- `destructiveHint` signals the LLM should be more careful before executing

## Before/After Example

**Before:**
```typescript
{
  name: "figma_get_file",
  description: "Get File Content - retrieve the full content of a Figma file."
  // No annotations
}
```

**After:**
```typescript
{
  name: "figma_get_file",
  description: "Get File Content - retrieve the full content of a Figma file.",
  annotations: {
    title: "Get File",
    readOnlyHint: true
  }
}
```

## Testing

- [x] TypeScript servers build successfully (Intercom)
- [x] Annotations appear in tool definitions
- [x] Annotation values match actual tool behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)