### PR TITLE
change youtube transcript api logic back

### DIFF
--- a/mcp_servers/youtube/server.py
+++ b/mcp_servers/youtube/server.py
@@ -1740,12 +1740,6 @@ def main(
             logger.info(f"Executing tool: get_video_transcript with video_id: {video_id}")
             
             try:
-
-                video_details = await get_video_details(video_id)
-                return {
-                    "video_id": video_id,
-                    "video_details": video_details,
-                }
                 # Use the initialized API with or without proxy
                 raw_transcript = youtube_transcript_api.fetch(video_id, languages=TRANSCRIPT_LANGUAGES).to_raw_data()
 


### PR DESCRIPTION
## Description
<!-- Please describe the changes in this PR. -->

Youtube native get caption api is not used for get the transcript, so change the logic back to our proxy solution.

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
<!-- e.g. Fixes #123 or Related to #456 -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New MCP feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
<!-- Describe how you have tested these changes. -->

## Checklist
<!-- Please delete options that are not relevant -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 