### PR TITLE
fix(confluence): preserve non-ASCII characters in JSON response

### DIFF
--- a/mcp_servers/confluence/server.py
+++ b/mcp_servers/confluence/server.py
@@ -553,7 +553,7 @@ def main(
             else:
                 raise ValueError(f"Unknown tool: {name}")
 
-            return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(result, indent=2, ensure_ascii=False))]
 
         except (AuthenticationError, TokenExpiredError, InvalidTokenError, ToolExecutionError) as e:
             logger.error(f"Confluence error in {name}: {e}")
@@ -561,14 +561,14 @@ def main(
                 "error": str(e),
                 "developer_message": getattr(e, "developer_message", ""),
             }
-            return [types.TextContent(type="text", text=json.dumps(error_response, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(error_response, indent=2, ensure_ascii=False))]
         except Exception as e:
             logger.exception(f"Unexpected error in tool {name}")
             error_response = {
                 "error": f"Unexpected error: {str(e)}",
                 "developer_message": f"Unexpected error in tool {name}: {type(e).__name__}: {str(e)}",
             }
-            return [types.TextContent(type="text", text=json.dumps(error_response, indent=2))]
+            return [types.TextContent(type="text", text=json.dumps(error_response, indent=2, ensure_ascii=False))]
 
     # Set up SSE transport
     sse = SseServerTransport("/messages/")


### PR DESCRIPTION
## Description
Fixed an issue where Japanese and other non-ASCII characters in Confluence MCP server JSON responses were being converted to Unicode escape sequences (`\uXXXX` format).

  Added `ensure_ascii=False` to `json.dumps()` calls to preserve non-ASCII characters properly.

  **Before:**
  ```json
  {
    "title": "\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u8ab2\u984c"
  }
```
  After:
```json
  {
    "title": "ドキュメントの課題"
  }
```

## Related issue
N/A

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New MCP feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify)

## How has this been tested?
(Add screenshots or recordings here if applicable.)
<!-- Describe how you have tested these changes. -->

## Checklist
<!-- Please delete options that are not relevant -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes 