### PR TITLE
fix(clickup): add assignees parameter to update_task tool

### DIFF
--- a/mcp_servers/clickup/server.py
+++ b/mcp_servers/clickup/server.py
@@ -508,6 +508,22 @@ def main(
                             "type": "integer",
                             "description": "New due date as Unix timestamp in milliseconds.",
                         },
+                        "assignees": {
+                            "type": "object",
+                            "description": "Object with 'add' and 'rem' arrays of user IDs to update assignees.",
+                            "properties": {
+                                "add": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                    "description": "User IDs to add as assignees.",
+                                },
+                                "rem": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                    "description": "User IDs to remove from assignees.",
+                                },
+                            },
+                        },
                     },
                 },
                 annotations=types.ToolAnnotations(
@@ -785,7 +801,8 @@ def main(
                 status = arguments.get("status")
                 priority = arguments.get("priority")
                 due_date = arguments.get("due_date")
-                result = await update_task(task_id, name, description, status, priority, due_date)
+                assignees = arguments.get("assignees")
+                result = await update_task(task_id, name, description, status, priority, due_date, assignees=assignees)
                 return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
             
             elif name == "clickup_search_tasks":


### PR DESCRIPTION
## Description
<!-- Please describe the changes in this PR. -->
- Add assignees schema with add/rem object format matching ClickUp API
- Wire assignees through handler to update_task function

## Related issue
<!-- Link or list the issue(s) this PR addresses. -->
<!-- e.g. Fixes #123 or Related to #456 -->
Fixes #947

## Type of change
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
<!-- Describe how you have tested these changes. -->
Manually verified against ClickUp API v2. Tested adding and removing assignees via 
update_task
 — both operations succeeded.
 
## Checklist
<!-- Please delete options that are not relevant -->
- [X] I have performed a self-review of my own code
- [X] New and existing tests pass locally with my changes 