### PR TITLE
fix: deny queries when database cannot be determined and allowed_databases is set (CWE-863)

### DIFF
--- a/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
+++ b/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
@@ -352,6 +352,12 @@ async def handle_read_query(arguments, db, write_detector, *_, exclude_json_resu
         extracted_db = extract_database_from_query(arguments["query"])
         if extracted_db:
             check_database_access(extracted_db, allowed_databases)
+        else:
+            raise ValueError(
+                "Access denied: Could not determine target database from query. "
+                "When allowed_databases is configured, queries must use fully "
+                "qualified table names (database.schema.table)."
+            )
 
     data, data_id = await db.execute_query(arguments["query"])
 
@@ -395,6 +401,12 @@ async def handle_write_query(arguments, db, _, allow_write, __, allowed_database
         extracted_db = extract_database_from_query(arguments["query"])
         if extracted_db:
             check_database_access(extracted_db, allowed_databases)
+        else:
+            raise ValueError(
+                "Access denied: Could not determine target database from query. "
+                "When allowed_databases is configured, queries must use fully "
+                "qualified table names (database.schema.table)."
+            )
 
     results, data_id = await db.execute_query(arguments["query"])
     return [types.TextContent(type="text", text=str(results))]


### PR DESCRIPTION
## Vulnerability Summary

**CWE:** [CWE-863 — Incorrect Authorization](https://cwe.mitre.org/data/definitions/863.html)
**Severity:** High
**Affected file:** `mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py`

### Data Flow

1. User (or LLM via prompt injection) calls `read_query` or `write_query` MCP tool with a free-form SQL string in `arguments["query"]`.
2. When `--allowed_databases` is configured, the server calls `extract_database_from_query(query)` to parse out the database name using a regex that looks for three-part `database.schema.table` names.
3. **Bug:** If the query does **not** contain a fully qualified name (e.g. `SELECT * FROM employees`), the regex returns `None`.
4. The existing code only checks authorization when `extracted_db` is truthy (`if extracted_db: check_database_access(...)`). When `None` is returned, the check is **skipped entirely**.
5. The query then executes against the **session-default database** (set via `SNOWFLAKE_DATABASE` env var or connection config), which may not be in the `allowed_databases` list.

**Result:** The `allowed_databases` restriction is trivially bypassed by omitting the database prefix from table references — the most common SQL pattern.

### Exploit Scenario

```
Admin deploys:  mcp_snowflake_server --transport http --allowed_databases=SAFE_DB
Session default: SNOWFLAKE_DATABASE=HR_DB (contains PII)
Snowflake role:  Has access to both SAFE_DB and HR_DB

Attacker calls read_query tool:
  {"query": "SELECT * FROM employees WHERE salary > 100000"}

extract_database_from_query → None (no three-part name)
→ if extracted_db: block is SKIPPED
→ Query executes against HR_DB → PII exposed
```

### Preconditions

1. `--allowed_databases` is configured (if unset, no restriction exists to bypass)
2. The Snowflake connection role has access to databases beyond those in `allowed_databases`
3. Attacker can invoke MCP tools (directly via unauthenticated HTTP, or via prompt injection)

All three are realistic in typical deployments. The HTTP transport binds to `0.0.0.0` with no authentication middleware.

---

## Fix Description

**Change:** Add an `else` branch to both `handle_read_query` (line 352) and `handle_write_query` (line 401) that raises `ValueError` when `extract_database_from_query` returns `None` and `allowed_databases` is configured.

**Rationale:** This converts the authorization check from **fail-open** (skip check when database is unknown) to **fail-closed** (deny when database cannot be determined). The error message instructs users to use fully qualified table names (`database.schema.table`).

**Scope:** 1 file changed, 12 insertions, 0 deletions. No dependencies, no new imports, no behavioral change when `allowed_databases` is not configured.

```diff
@@ handle_read_query (line 352) @@
         extracted_db = extract_database_from_query(arguments["query"])
         if extracted_db:
             check_database_access(extracted_db, allowed_databases)
+        else:
+            raise ValueError(
+                "Access denied: Could not determine target database from query. "
+                "When allowed_databases is configured, queries must use fully "
+                "qualified table names (database.schema.table)."
+            )

@@ handle_write_query (line 401) — identical else branch @@
```

The `handle_tool_errors` decorator on the MCP tool dispatcher already catches exceptions and returns error messages to the client, so this integrates cleanly with the existing error handling.

---

## Test Results Summary

- **Bypass confirmed (pre-fix):** Unqualified queries like `SELECT * FROM table` skip the `allowed_databases` check entirely when `extract_database_from_query` returns `None`.
- **Fix verified (post-fix):** The same queries now raise `ValueError` with a clear error message, blocking execution.
- **No regression:** Fully qualified queries (`DB.SCHEMA.TABLE`) continue to work as before — allowed databases pass, disallowed databases are rejected by `check_database_access`.
- **No behavior change** when `allowed_databases` is not configured (the outer `if allowed_databases:` guard prevents the new code from running).

---

## Disprove Analysis

We systematically attempted to disprove this finding:

| Check | Result |
|-------|--------|
| **Auth check** | No authentication on the MCP HTTP endpoint. No `login_required`, Bearer tokens, API keys, or auth middleware. `x-auth-data` header is for Snowflake credentials, not server access control. |
| **Network check** | Server binds to `0.0.0.0` with no CORS restrictions. Dockerfile exposes port 5000 directly. No reverse proxy or VPN config in the repo. |
| **Deployment context** | No service mesh, sidecar proxy, or network-level auth found in the repository. |
| **Caller trace** | `extract_database_from_query` is called exactly twice (lines 352, 401), both from MCP tool handlers processing user-supplied `arguments["query"]` — fully attacker-controlled input. |
| **Input validation** | No `sanitize`, `validate`, `escape`, `clean`, `whitelist`, or `allowlist` functions found. Only `write_detector.analyze_query()` (blocks writes in read path) and the regex extraction exist. |
| **Prior reports** | Issues #712 (general security) and #1400 (timing side-channel) exist. No prior report of this specific CWE-863 bypass. |
| **Security policy** | No SECURITY.md found in the repository. |
| **Recent commits** | No prior security fix for this specific issue. |

### Existing Mitigations

- **Snowflake RBAC** may limit damage if the role is tightly scoped, but `allowed_databases` exists precisely for cases where the role is broader than desired. Its bypass is a real authorization flaw regardless.
- No other application-layer mitigations found.

### Known Limitations (Pre-existing, Not Introduced by Fix)

- **Multi-database JOINs:** `SELECT * FROM ALLOWED_DB.PUBLIC.T1 JOIN FORBIDDEN_DB.PUBLIC.T2 ON ...` — only the first three-part name is extracted, so the second database is not checked. This is a pre-existing limitation of the regex-based approach.
- **Case sensitivity:** `extract_database_from_query` uppercases the result, but `check_database_access` does case-sensitive comparison. If `allowed_databases` is specified in lowercase, legitimate queries may be denied.

These are design limitations worth tracking separately but do not diminish this fix.

### Verdict

**CONFIRMED_VALID** — High confidence. The fail-open authorization bypass is straightforward, exploitable, and the fix is correct and minimal.

---