### PR TITLE
fix: escape user input in Google Drive API queries to prevent query injection (CWE-943)

### DIFF
--- a/mcp_servers/google_sheets_toolathlon/src/mcp_google_sheets/server.py
+++ b/mcp_servers/google_sheets_toolathlon/src/mcp_google_sheets/server.py
@@ -1310,9 +1310,11 @@ def search_spreadsheets(query: str,
 
     # Build the search query for Google Drive
     # Search only for spreadsheets and match the query in name or fullText
+    # Escape single quotes to prevent query injection in Drive API query language
+    sanitized_query = query.replace("\\", "\\\\").replace("'", "\\'")
     search_query = (
         f"mimeType='application/vnd.google-apps.spreadsheet' and "
-        f"(name contains '{query}' or fullText contains '{query}')"
+        f"(name contains '{sanitized_query}' or fullText contains '{sanitized_query}')"
     )
 
     try:


### PR DESCRIPTION
## Vulnerability Summary

**CWE**: [CWE-943](https://cwe.mitre.org/data/definitions/943.html) — Improper Neutralization of Special Elements in Data Query Logic
**Severity**: Medium
**Location**: `mcp_servers/google_sheets_toolathlon/src/mcp_google_sheets/server.py`, `search_spreadsheets()` function (line ~1313)

### Data Flow

1. **Source**: The `query` parameter of the `search_spreadsheets` MCP tool, supplied by MCP client tool calls (derived from user prompts via LLM)
2. **Sink**: String-interpolated into a Google Drive API `files.list` query: `f"(name contains '{query}' or fullText contains '{query}')"` 
3. **Missing control**: No escaping or validation of `query` before interpolation into the Drive query language

### Exploit Example (pre-fix)

**Payload**:
```
query = "x' or mimeType != 'application/vnd.google-apps.spreadsheet' or name contains '"
```

**Resulting Drive API query**:
```
mimeType='application/vnd.google-apps.spreadsheet' and (name contains 'x' or mimeType != 'application/vnd.google-apps.spreadsheet' or name contains '' or fullText contains 'x' or mimeType != 'application/vnd.google-apps.spreadsheet' or name contains ''  )
```

This bypasses the `mimeType` filter, returning all files (Docs, PDFs, etc.) accessible to the service account — not just spreadsheets.

---

## Fix Description

**Change**: Escape backslashes and single quotes in the `query` parameter before interpolation into the Drive API query string.

```python
sanitized_query = query.replace("\\", "\\\\").replace("'", "\\'")
```

**Rationale**: Google's own [Drive API query documentation](https://developers.google.com/drive/api/guides/ref-search-terms) specifies that single quotes within query string values must be escaped with `\'`. Backslashes must also be escaped to prevent escaping the escape character. This is the same pattern already used in the sibling `google_drive/server.py` (line 139), confirming codebase awareness of this requirement.

The fix is **minimal** (3 lines added, 1 line modified) and **non-breaking** — legitimate search queries containing apostrophes will now work correctly rather than causing API errors.

---

## Test Results

| Test | Result |
|---|---|
| Normal search query (`"budget 2024"`) | ✅ Pass — unchanged behavior |
| Query with apostrophe (`"Q1's results"`) | ✅ Pass — correctly escaped, no API error |
| Injection payload (`"x' or mimeType != '..."`) | ✅ Pass — payload is escaped and treated as literal search text |
| Empty query | ✅ Pass — no change in behavior |
| Backslash in query (`"path\\to"`) | ✅ Pass — backslash correctly escaped |

---

## Disprove Analysis

We systematically attempted to disprove this finding across 8 dimensions:

### Authentication Check
The MCP server uses Google OAuth2/service account credentials for Drive API access. There is **no per-request authentication** for MCP tool calls — once the server is running, any connected MCP client can invoke tools. The `@tool` decorator does not include auth middleware.

### Network Check
The server binds to **`0.0.0.0`** by default (line 293), making it accessible on all network interfaces. No CORS restrictions, no `ALLOWED_HOSTS`. This is network-accessible.

### Deployment Check
A Dockerfile exists but no docker-compose or k8s manifests. Nothing indicates VPN/reverse-proxy requirement. Documented as an MCP server for Claude Desktop or other MCP clients.

### Caller Trace
`search_spreadsheets` is a `@tool`-decorated function called directly by MCP clients via JSON-RPC. The `query` parameter comes from the LLM's tool call arguments, derived from user prompts. **User-controlled input reaches the vulnerable code path.**

### Input Validation
Before the fix: **zero validation** on the `query` parameter. After the fix: proper escaping of `\` and `'` characters per Google's documentation.

### Prior Reports
Three open security issues exist (#1407 — prompt injection, #712 — generic security vuln, #1400 — timing attack). **None reference this Drive query injection.**

### Security Policy
No `SECURITY.md` found in the repository.

### Recent Commits
Only 2 commits on the affected file: this fix and an earlier API spec update.

### Verdict: **CONFIRMED_VALID** (high confidence)

The vulnerability is real — unescaped user input is interpolated into Google Drive's text-based query language, allowing injection of arbitrary query operators. The fix correctly implements Google's documented escaping mechanism. I was unable to disprove the finding.

---

## Mitigations Already Present (limiting severity to Medium)

- **Google Drive API scope**: Only returns files accessible to the authenticated credentials — no cross-tenant access
- **Read-only impact**: `files.list` is read-only; no data modification possible
- **LLM mediation**: The LLM decides tool call parameters, providing a weak layer of indirection

---

## Additional Injection Points (not fixed in this PR)

Two additional injection points with the same pattern exist in the same file. These use `folder_id`/`parent_folder_id` parameters interpolated into Drive queries without escaping:

| Location | Pattern | Status |
|---|---|---|
| `server.py:1127` (`list_spreadsheets`) | `f" and '{target_folder_id}' in parents"` | **Unfixed** |
| `server.py:1255` (`list_folders`) | `f" and '{parent_folder_id}' in parents"` | **Unfixed** |

A shared `_escape_drive_query_value()` helper function would be ideal for addressing all three consistently. I've scoped this PR to the confirmed `search_spreadsheets` fix to keep it minimal and reviewable, but happy to expand if preferred.

---

## References

- [CWE-943: Improper Neutralization of Special Elements in Data Query Logic](https://cwe.mitre.org/data/definitions/943.html)
- [Google Drive API: Search for files & folders](https://developers.google.com/drive/api/guides/ref-search-terms)
- [OWASP: Injection](https://owasp.org/www-community/Injection_Flaws)