### PR TITLE
notion_mcpmark: cap Notion upstream + request timeouts

### DIFF
--- a/mcp_servers/notion_mcpmark/scripts/start-server.ts
+++ b/mcp_servers/notion_mcpmark/scripts/start-server.ts
@@ -180,6 +180,10 @@ Examples:
 
     // Handle POST requests for client-to-server communication (stateless per-request model)
     app.post('/mcp', async (req, res) => {
+      // Belt-and-braces in case the upstream axios timeout is bypassed: cap each
+      // request well under Cloud Run's 300s so a hang terminates with a normal
+      // 5xx instead of tearing down the client's MCP stream.
+      req.setTimeout(90_000)
       // Extract Notion token from request header
       const notionToken = extractNotionToken(req)
 

--- a/mcp_servers/notion_mcpmark/src/openapi-mcp-server/client/http-client.ts
+++ b/mcp_servers/notion_mcpmark/src/openapi-mcp-server/client/http-client.ts
@@ -39,6 +39,10 @@ export class HttpClient {
       definition: openApiSpec,
       axiosConfigDefaults: {
         baseURL: config.baseUrl,
+        // Without this, a half-open TCP connection to Notion's API hangs the
+        // handler until Cloud Run's 300s request limit kills it with 504,
+        // which closes the client's MCP stream and surfaces as ClosedResourceError.
+        timeout: 60_000,
         headers: {
           'Content-Type': 'application/json',
           'User-Agent': 'notion-mcp-server',


### PR DESCRIPTION
## Summary
- Set axios `timeout: 60_000` on the Notion HttpClient so a half-open upstream surfaces as a structured `HttpClientError` (caught by `proxy.ts` and returned as JSON) instead of hanging the handler.
- Add `req.setTimeout(90_000)` on `POST /mcp` as defense-in-depth, well under Cloud Run's 300s request cap.

## Why
bursts of Python `anyio.ClosedResourceError` mid-session. The server-side trace in gcloud shows **7 × 504 over 48h from the same customer IP, all at exactly 300.000s** — Cloud Run's per-request timeout. 828/1000 of that customer's successful calls returned in <1s and 172 in 1–10s; **zero** in 10–299s, then 7 at ≥300s. That distribution is consistent with a TCP half-open to `api.notion.com`, not "slow Notion".

Today `http-client.ts` does not pass a `timeout` to axios, so its default of `0` (infinite) applies. When the upstream silently stops ACKing, the handler blocks until Cloud Run kills it with 504, which closes the client's streamable-HTTP stream — the MCP `anyio.MemoryObjectStream` goes into closed state, and every subsequent `call_tool()` on that session raises `ClosedResourceError` until the client rebuilds the session.

## Test plan
- [x] `tsc -build` passes
- [ ] Deploy to `notion-mcpmark-mcp-server` and confirm `504 @ 300s` count drops to zero in gcloud over next 24h
- [ ] Confirm customer's MCPMark rerun no longer shows `ClosedResourceError` bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)