### PR TITLE
notion_mcpmark: wrap upstream timeouts as HttpClientError

### DIFF
--- a/mcp_servers/notion_mcpmark/src/openapi-mcp-server/client/http-client.ts
+++ b/mcp_servers/notion_mcpmark/src/openapi-mcp-server/client/http-client.ts
@@ -193,6 +193,17 @@ export class HttpClient {
 
         throw new HttpClientError(error.response.statusText || 'Request failed', error.response.status, error.response.data, headers)
       }
+      // No response (timeout, DNS, socket hangup) — wrap so proxy.ts can return
+      // a structured tool-result error instead of bubbling as a protocol-level
+      // McpError. Keeps the CallToolResult schema consistent for the agent.
+      if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT' || error.code === 'ECONNRESET') {
+        console.error('Error in http client (no response)', error.code, error.message)
+        throw new HttpClientError(
+          error.message || 'Upstream request failed',
+          504,
+          { code: error.code, message: error.message },
+        )
+      }
       throw error
     }
   }


### PR DESCRIPTION
## Summary
Follow-up to #1572. Wraps axios no-response failures (`ECONNABORTED`, `ETIMEDOUT`, `ECONNRESET`) as `HttpClientError(504, ...)` so the existing catch in `proxy.ts` returns them as a structured `CallToolResult` error instead of letting the raw `AxiosError` bubble up and surface on the Python client as an `McpError`.

## Why
After #1572 landed, the agent sees a split schema for upstream failures:
- **Case 1 — Notion returned HTTP 4xx/5xx:** `HttpClientError` → `CallToolResult` with `content[0].text = '{"status":"error", ...notion fields...}'`
- **Case 2 — axios timeout (no `.response`):** raw `AxiosError` rethrown → MCP SDK emits JSON-RPC error → client raises `McpError` with `message = "timeout of 60000ms exceeded"`

The customer's agent handles Case 1 cleanly (structured JSON the model can reason about) but gets a bare string in Case 2. Unifying the two paths means every upstream failure reaches the model in the same shape.

Schema after this change:
```json
{
  "status": "error",
  "code": "ECONNABORTED",
  "message": "timeout of 60000ms exceeded"
}
```

## Test plan
- [x] `tsc -build` passes
- [ ] Customer confirms their agent's error handling treats axios-timeout and Notion-4xx the same way
- [ ] gcloud logs show `Error in http client (no response)` lines on the revisions after deploy, each corresponding to a 60s axios abort — those are the ones that *would have been* 504@300s before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)