### PR TITLE
Sanitize error messages in Snowflake MCP server to prevent credential leakage (CWE-200)

### DIFF
--- a/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
+++ b/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
@@ -3,6 +3,7 @@ import contextvars
 import base64
 import importlib.metadata
 import json
+import re
 import logging
 import os
 from functools import wraps
@@ -82,12 +83,30 @@ def extract_credentials(request_or_scope) -> dict[str, Any] | None:
             return mapped_creds if mapped_creds else None
             
         except Exception as e:
-            logger.warning(f"Failed to parse x-auth-data: {e}")
+            logger.warning("Failed to parse x-auth-data header")
             return None
             
     return None
 
 
+
+
+
+
+# Patterns that may contain sensitive credential information in error messages
+_SENSITIVE_PATTERNS = [
+    re.compile(r'(password\s*[=:]\s*)\S+', re.IGNORECASE),
+    re.compile(r'(token\s*[=:]\s*)\S+', re.IGNORECASE),
+    re.compile(r'(private.?key\S*\s*[=:]\s*)\S+', re.IGNORECASE),
+]
+
+
+def _sanitize_error_message(error: Exception) -> str:
+    """Remove potentially sensitive credential data from error messages."""
+    msg = str(error)
+    for pattern in _SENSITIVE_PATTERNS:
+        msg = pattern.sub(r'\1[REDACTED]', msg)
+    return msg
 
 
 def handle_tool_errors(func: Callable) -> Callable:
@@ -98,8 +117,9 @@ def handle_tool_errors(func: Callable) -> Callable:
         try:
             return await func(*args, **kwargs)
         except Exception as e:
-            logger.error(f"Error in {func.__name__}: {str(e)}")
-            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+            sanitized_msg = _sanitize_error_message(e)
+            logger.error(f"Error in {func.__name__}: {sanitized_msg}")
+            return [types.TextContent(type="text", text=f"Error: {sanitized_msg}")]
 
     return wrapper
 
@@ -716,8 +736,8 @@ async def prefetch_tables(db: SnowflakeDB, credentials: dict) -> dict:
         return tables_brief
 
     except Exception as e:
-        logger.error(f"Error prefetching table descriptions: {e}")
-        return f"Error prefetching table descriptions: {e}"
+        logger.error(f"Error prefetching table descriptions: {_sanitize_error_message(e)}")
+        return f"Error prefetching table descriptions: {_sanitize_error_message(e)}"
 
 
 async def main(


### PR DESCRIPTION
## Summary

This PR hardens error handling in the Snowflake MCP server (`mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py`) to prevent potentially sensitive credential material from being written to logs or returned to MCP clients via tool error responses.

- **CWE:** CWE-200 (Exposure of Sensitive Information to an Unauthorized Actor)
- **Severity:** Low–Medium (defensive hardening; no confirmed PoC of a live leak)
- **Affected file:** `mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py`
- **Affected functions:** `handle_tool_errors` (error decorator used by every tool handler), `prefetch_tables`, and the `extract_credentials` x-auth-data parse warning.

## The issue

Three error paths in the Snowflake server interpolated raw exception strings into log messages and/or user-visible MCP responses:

1. `handle_tool_errors` — wraps every tool handler. On any exception it both logged `str(e)` and returned `f"Error: {str(e)}"` as `TextContent` to the MCP client.
2. `prefetch_tables` — logged and returned `f"Error prefetching table descriptions: {e}"` on failure.
3. `extract_credentials` — on failure to parse the `x-auth-data` header, logged `f"Failed to parse x-auth-data: {e}"`. The header carries base64-encoded JSON of credentials, and parser exceptions can include excerpts of the malformed input.

Data flow: a request reaches a tool handler → handler calls into the Snowflake connector / Snowpark / credential setup → an exception is raised whose stringification may embed credential-bearing context (e.g. connection-string fragments, header parse buffers, key material errors) → that string is logged and returned verbatim to the caller.

We did not produce a PoC that demonstrates a live `password=...` value being echoed by snowflake-connector itself; typical Snowflake driver errors include account/user/role but not raw secrets. The risk is more concrete for the `x-auth-data` parser path (where the input *is* credential material) and for any wrapper code that constructs its own error strings from connection params. Because `handle_tool_errors` is the central error sink for every tool, a single such wrapper anywhere in the call graph would surface to clients.

## The fix

Two small, low-risk changes:

1. Add a `_sanitize_error_message(e)` helper that redacts `password=...`, `token=...`, and `private_key=...` (case-insensitive) from any exception string before it is logged or returned. Apply it in `handle_tool_errors` and `prefetch_tables`.
2. Drop the exception detail from the `x-auth-data` parse warning — log a generic message instead of the parser exception, since the input is by definition credential data.

```python
_SENSITIVE_PATTERNS = [
    re.compile(r'(password\s*[=:]\s*)\S+', re.IGNORECASE),
    re.compile(r'(token\s*[=:]\s*)\S+', re.IGNORECASE),
    re.compile(r'(private.?key\S*\s*[=:]\s*)\S+', re.IGNORECASE),
]

def _sanitize_error_message(error: Exception) -> str:
    msg = str(error)
    for pattern in _SENSITIVE_PATTERNS:
        msg = pattern.sub(r'\1[REDACTED]', msg)
    return msg
```

Rationale:
- Centralised at the decorator means every tool benefits without touching individual handlers.
- Pattern-based redaction is conservative (only modifies strings that already look like `key=value` credential pairs); legitimate error messages are unaffected.
- The header-parse change removes a path where the *input itself* is sensitive — there's no diagnostic value in echoing it to logs.

## Testing

- Verified the patch applies cleanly on `main` and the diff is limited to the one file (25 insertions, 5 deletions).
- Manually exercised the redaction helper against representative strings:
  - `"connect failed: password=hunter2 user=admin"` → `"connect failed: password=[REDACTED] user=admin"`
  - `"auth: token=eyJhbGciOi..."` → `"auth: token=[REDACTED]"`
  - `"private_key=-----BEGIN..."` → `"private_key=[REDACTED]"`
  - Strings with no credential-shaped tokens pass through unchanged.
- No behavioural changes for the success path of any tool; only the error-message string is rewritten.

## Security analysis

Preconditions for exploitation:
- An attacker (or a misconfigured client) can send MCP requests to the Snowflake server.
- An exception raised during request handling produces a string that contains literal `password=...`, `token=...`, or `private_key=...` substrings — most likely from connection-config formatting code or from the `x-auth-data` parser path.

Where this is met, the original code surfaces the secret to the MCP client (as `TextContent`) and to the server logs. The fix breaks both of those leakage paths centrally, without changing tool semantics or error visibility for legitimate diagnostics.

This is hardening rather than a fix for a demonstrated live leak in the Snowflake driver itself; the value is in closing a class of error-message-based leaks at the choke point used by every tool handler.

### Adversarial review

Before submitting, we tried to disprove this. We checked whether Snowflake's connector errors actually embed raw secrets (they generally don't — they include account/user/role), whether MCP framework code already sanitises tool error responses (it doesn't — `TextContent` is returned as-is), and whether the `x-auth-data` warning would only fire under operator-controlled conditions (it fires on any malformed client header, so it's attacker-influenced). The remaining residual risk — wrapper/glue code that interpolates connection params into its own exception strings, plus the header-parse path where the input itself is credential material — is real enough to justify the redaction, and the patch is small enough that it carries essentially no regression risk.

### Scope note

This patch only covers the Snowflake server's central error decorator and two specific call sites. Other MCP servers in this repo use similar `f"...{e}"` patterns and may benefit from a comparable pass; happy to follow up with additional PRs if the maintainers would like.

cc @lewiswigmore
