### PR TITLE
Fix CWE-863: allowed_databases bypass via unqualified SQL in Snowflake MCP server

### DIFF
--- a/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
+++ b/mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py
@@ -352,6 +352,12 @@ async def handle_read_query(arguments, db, write_detector, *_, exclude_json_resu
         extracted_db = extract_database_from_query(arguments["query"])
         if extracted_db:
             check_database_access(extracted_db, allowed_databases)
+        else:
+            raise ValueError(
+                "Access denied: Could not determine target database from query. "
+                "When allowed_databases is configured, queries must use fully "
+                "qualified table names (database.schema.table)."
+            )
 
     data, data_id = await db.execute_query(arguments["query"])
 
@@ -395,6 +401,12 @@ async def handle_write_query(arguments, db, _, allow_write, __, allowed_database
         extracted_db = extract_database_from_query(arguments["query"])
         if extracted_db:
             check_database_access(extracted_db, allowed_databases)
+        else:
+            raise ValueError(
+                "Access denied: Could not determine target database from query. "
+                "When allowed_databases is configured, queries must use fully "
+                "qualified table names (database.schema.table)."
+            )
 
     results, data_id = await db.execute_query(arguments["query"])
     return [types.TextContent(type="text", text=str(results))]


### PR DESCRIPTION
## Summary

The Snowflake MCP server's `allowed_databases` whitelist can be bypassed by submitting SQL queries that don't use fully-qualified table names. When the database can't be parsed out of the query, the access check is silently skipped and the query runs against whatever default database the underlying Snowflake session resolves to.

- **CWE:** CWE-863 (Incorrect Authorization)
- **File:** `mcp_servers/snowflake_toolathlon/src/mcp_snowflake_server/server.py`
- **Affected handlers:** `handle_read_query`, `handle_write_query`

## Vulnerability details

In the current code:

```python
if allowed_databases is not None:
    extracted_db = extract_database_from_query(arguments["query"])
    if extracted_db:
        check_database_access(extracted_db, allowed_databases)
    # else: silently fall through and execute the query
```

`extract_database_from_query` uses a regex that only matches the `database.schema.table` form. Common SQL like `SELECT * FROM secret_table` or `SELECT * FROM schema.table` returns `None`, so `check_database_access` is never invoked and the query is forwarded to Snowflake using the session's default/current database.

### Data flow

1. MCP client (attacker) calls `read_query` / `write_query` with an unqualified SQL statement.
2. `extract_database_from_query(query)` returns `None`.
3. The `if extracted_db:` branch is skipped — no authorization check occurs.
4. `db.execute_query` runs the SQL under the underlying Snowflake credentials, which typically have access to databases beyond the whitelist (the whole point of `allowed_databases` is to narrow broader credentials).

### Preconditions

- The server is configured with an `allowed_databases` whitelist.
- The attacker can invoke `read_query` or `write_query` (a normal MCP client capability).
- The underlying Snowflake credentials can reach databases outside the whitelist — this is the typical and intended deployment, since the whitelist exists precisely to constrain such credentials.

## Fix

When `allowed_databases` is configured and the target database cannot be positively identified from the query, deny the request with a clear error:

```python
if allowed_databases is not None:
    extracted_db = extract_database_from_query(arguments["query"])
    if extracted_db:
        check_database_access(extracted_db, allowed_databases)
    else:
        raise ValueError(
            "Access denied: Could not determine target database from query. "
            "When allowed_databases is configured, queries must use fully "
            "qualified table names (database.schema.table)."
        )
```

This is a fail-closed change: if the policy can't be evaluated, the query is rejected rather than executed. The error message tells the client how to comply (use `database.schema.table`).

The change is applied to both `handle_read_query` and `handle_write_query`. Other handlers (`list_schemas`, `describe_table`, `create_*`, `drop_*`) take `database` as an explicit argument and already pass it through `check_database_access`, so they are not affected by this bypass.

## What I tested

- Reviewed all call sites of `extract_database_from_query` and `check_database_access` to confirm the bypass is unique to the two query handlers.
- Confirmed that when `allowed_databases is None` (whitelist not configured), behavior is unchanged — no new error is raised.
- Confirmed legitimate use of fully-qualified names (`db.schema.table`) continues to work and is properly checked against the whitelist.
- Verified the diff is minimal: 12 added lines, 0 removed, single file.

## Adversarial review

Before submitting I tried to disprove this finding. The main alternatives I considered: (1) maybe Snowflake's own role/grant model would block cross-database access — but `allowed_databases` only makes sense as a deployment pattern when the underlying credentials are intentionally broader, so relying on Snowflake grants would make the setting redundant; (2) maybe `extract_database_from_query` is more permissive than it appears — it isn't, the regex specifically requires three dotted components; (3) maybe a higher layer enforces qualification — there is none in this server. The bypass is real and the fail-closed fix is the minimal correct response.

cc @lewiswigmore
