### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@
 
 ```bash
 # Run any MCP Integration
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/klavis-ai-klavis)](https://takoapi.com/agents/klavis-ai-klavis)
+
 docker pull ghcr.io/klavis-ai/github-mcp-server:latest
 docker run -p 5000:5000 ghcr.io/klavis-ai/github-mcp-server:latest
 


### PR DESCRIPTION
Hi! 👋 **klavis** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/klavis-ai-klavis

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building klavis! 🙏