### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/ai-klavis-strata)](https://mcpindex.ai/server/ai-klavis-strata)
+
 <div align="center">
   <picture>
     <img src="./docs/images/logo/cover.png" width="100%">


### PR DESCRIPTION
Hey, Klavis's registered MCP server came back clean on mcpindex's description-level screen (injection/manipulation check, nothing deeper). Added the badge to your README in case it's useful. Advisory only, not a security cert. Feel free to close if not a fit. 