### PR TITLE
fix(notion): error envelopes are misclassified, destroyed by normalization, and reported as successes

### DIFF
--- a/mcp_servers/notion/requirements-test.txt
+++ b/mcp_servers/notion/requirements-test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+pytest-asyncio

--- a/mcp_servers/notion/server.py
+++ b/mcp_servers/notion/server.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from collections.abc import AsyncIterator
+from functools import partial
 from typing import Any, Dict
 import base64
 
@@ -237,8 +238,50 @@ def normalize_property_item(raw_item: dict) -> dict:
     return normalized
 
 
+class NotionToolError(Exception):
+    """Raised when a Notion tool call failed, carrying the structured error envelope.
+
+    The MCP framework builds CallToolResult with isError=False for any handler that
+    returns normally, and sets isError=True only when the handler raises, using
+    str(exception) as the content. Tool functions here catch their exceptions and
+    return an error dict, so before this the handler never raised and every failure
+    reached the client as a successful call whose body happened to be an error object.
+
+    Serialising the envelope as the exception message keeps both properties: the
+    protocol's error flag is set, and the caller still receives the structured detail
+    rather than a flattened string. google_docs in this repository already raises for
+    the same reason.
+    """
+
+    def __init__(self, envelope: dict) -> None:
+        self.envelope = envelope
+        super().__init__(json.dumps(envelope, indent=2))
+
+
+def apply_normalizer(result: Any, normalizer) -> Any:
+    """Normalize a successful tool result, or raise if the tool reported a failure.
+
+    Tool functions return either a Notion payload or the envelope from
+    handle_notion_error, and both are plain dicts, so a type check cannot tell them
+    apart. Passing an envelope to a normalizer destroyed it: the mapping-rule
+    normalizers (page, database, comment, list) found none of their source keys and
+    returned {}, while the ones that copy "type" through returned a plausible-looking
+    object such as {"userType": "not_found_error"}, because the envelope's "type" key
+    collides with the "type" every Notion object carries.
+
+    Detecting the envelope here serves both purposes: the failure is no longer
+    flattened by normalization, and raising it lets the framework mark the response
+    as an error so the client can detect the failure from the protocol rather than by
+    inspecting the payload.
+    """
+    if is_error_envelope(result):
+        raise NotionToolError(result)
+    return normalizer(result) if isinstance(result, dict) else result
+
+
 from tools import (
     auth_token_context,
+    is_error_envelope,
     create_page,
     get_page,
     update_page_properties,
@@ -924,7 +967,7 @@ def main(
                     cover=arguments.get("cover"),
                 )
                 # Normalize the response
-                normalized = normalize_page(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_page)
                 return [
                     types.TextContent(
                         type="text",
@@ -932,13 +975,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_page":
             try:
                 result = await get_page(
@@ -946,7 +989,7 @@ def main(
                     filter_properties=arguments.get("filter_properties"),
                 )
                 # Normalize the response
-                normalized = normalize_page(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_page)
                 return [
                     types.TextContent(
                         type="text",
@@ -954,13 +997,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_update_page_properties":
             try:
                 result = await update_page_properties(
@@ -972,7 +1015,7 @@ def main(
                     in_trash=arguments.get("in_trash"),
                 )
                 # Normalize the response
-                normalized = normalize_page(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_page)
                 return [
                     types.TextContent(
                         type="text",
@@ -980,13 +1023,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_query_database":
             try:
                 result = await query_database(
@@ -1000,7 +1043,7 @@ def main(
                     in_trash=arguments.get("in_trash"),
                 )
                 # Normalize the response (list of pages)
-                normalized = normalize_list_response(result, normalize_page) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_page))
                 return [
                     types.TextContent(
                         type="text",
@@ -1008,18 +1051,18 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_database":
             try:
                 result = await get_database(database_id=arguments.get("database_id"))
                 # Normalize the response
-                normalized = normalize_database(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_database)
                 return [
                     types.TextContent(
                         type="text",
@@ -1027,13 +1070,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_create_database":
             try:
                 result = await create_database(
@@ -1045,7 +1088,7 @@ def main(
                     description=arguments.get("description"),
                 )
                 # Normalize the response
-                normalized = normalize_database(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_database)
                 return [
                     types.TextContent(
                         type="text",
@@ -1053,13 +1096,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_update_database":
             try:
                 result = await update_database(
@@ -1072,7 +1115,7 @@ def main(
                     archived=arguments.get("archived"),
                 )
                 # Normalize the response
-                normalized = normalize_database(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_database)
                 return [
                     types.TextContent(
                         type="text",
@@ -1080,13 +1123,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_create_database_item":
             try:
                 result = await create_database_item(
@@ -1097,7 +1140,7 @@ def main(
                     cover=arguments.get("cover"),
                 )
                 # Normalize the response (returns a page)
-                normalized = normalize_page(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_page)
                 return [
                     types.TextContent(
                         type="text",
@@ -1105,13 +1148,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
 
         elif name == "notion_search":
             try:
@@ -1131,7 +1174,7 @@ def main(
                         elif obj_type == "database":
                             return normalize_database(item)
                         return item
-                    normalized = normalize_list_response(result, normalize_search_item)
+                    normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_search_item))
                 else:
                     normalized = result
                 return [
@@ -1141,18 +1184,18 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_user":
             try:
                 result = await get_user(user_id=arguments.get("user_id"))
                 # Normalize the response
-                normalized = normalize_user(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_user)
                 return [
                     types.TextContent(
                         type="text",
@@ -1160,13 +1203,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_list_users":
             try:
                 result = await list_users(
@@ -1174,7 +1217,7 @@ def main(
                     page_size=arguments.get("page_size"),
                 )
                 # Normalize the response (list of users)
-                normalized = normalize_list_response(result, normalize_user) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_user))
                 return [
                     types.TextContent(
                         type="text",
@@ -1182,13 +1225,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
 
         elif name == "notion_create_comment":
             try:
@@ -1198,7 +1241,7 @@ def main(
                     discussion_id=arguments.get("discussion_id"),
                 )
                 # Normalize the response
-                normalized = normalize_comment(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_comment)
                 return [
                     types.TextContent(
                         type="text",
@@ -1206,13 +1249,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_comments":
             try:
                 result = await get_comments(
@@ -1221,7 +1264,7 @@ def main(
                     page_size=arguments.get("page_size"),
                 )
                 # Normalize the response (list of comments)
-                normalized = normalize_list_response(result, normalize_comment) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_comment))
                 return [
                     types.TextContent(
                         type="text",
@@ -1229,18 +1272,18 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_me":
             try:
                 result = await get_me()
                 # Normalize the response (returns a user/bot object)
-                normalized = normalize_user(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_user)
                 return [
                     types.TextContent(
                         type="text",
@@ -1248,13 +1291,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_retrieve_page_property":
             try:
                 result = await retrieve_page_property(
@@ -1264,7 +1307,7 @@ def main(
                     page_size=arguments.get("page_size"),
                 )
                 # Normalize the response (property item)
-                normalized = normalize_property_item(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_property_item)
                 return [
                     types.TextContent(
                         type="text",
@@ -1272,18 +1315,18 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_retrieve_block":
             try:
                 result = await retrieve_block(block_id=arguments.get("block_id"))
                 # Normalize the response
-                normalized = normalize_block(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_block)
                 return [
                     types.TextContent(
                         type="text",
@@ -1291,13 +1334,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_update_block":
             try:
                 result = await update_block(
@@ -1306,7 +1349,7 @@ def main(
                     archived=arguments.get("archived"),
                 )
                 # Normalize the response
-                normalized = normalize_block(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_block)
                 return [
                     types.TextContent(
                         type="text",
@@ -1314,18 +1357,18 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_delete_block":
             try:
                 result = await delete_block(block_id=arguments.get("block_id"))
                 # Normalize the response
-                normalized = normalize_block(result) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, normalize_block)
                 return [
                     types.TextContent(
                         type="text",
@@ -1333,13 +1376,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_get_block_children":
             try:
                 result = await get_block_children(
@@ -1348,7 +1391,7 @@ def main(
                     page_size=arguments.get("page_size"),
                 )
                 # Normalize the response (list of blocks)
-                normalized = normalize_list_response(result, normalize_block) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_block))
                 return [
                     types.TextContent(
                         type="text",
@@ -1356,13 +1399,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
         elif name == "notion_append_block_children":
             try:
                 result = await append_block_children(
@@ -1371,7 +1414,7 @@ def main(
                     after=arguments.get("after"),
                 )
                 # Normalize the response (list of blocks)
-                normalized = normalize_list_response(result, normalize_block) if isinstance(result, dict) else result
+                normalized = apply_normalizer(result, partial(normalize_list_response, item_normalizer=normalize_block))
                 return [
                     types.TextContent(
                         type="text",
@@ -1379,13 +1422,13 @@ def main(
                     )
                 ]
             except Exception as e:
+                # Re-raise rather than returning the message as content. The MCP
+                # framework sets CallToolResult.isError only for a handler that
+                # raises; returning here produced a successful result whose body
+                # happened to read "Error: ...", which a client cannot detect as a
+                # failure without parsing prose.
                 logger.exception(f"Error executing tool {name}: {e}")
-                return [
-                    types.TextContent(
-                        type="text",
-                        text=f"Error: {str(e)}",
-                    )
-                ]
+                raise
 
         return [
             types.TextContent(

--- a/mcp_servers/notion/tests/conftest.py
+++ b/mcp_servers/notion/tests/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest_plugins = ('pytest_asyncio',)

--- a/mcp_servers/notion/tests/fake_sdk/sitecustomize.py
+++ b/mcp_servers/notion/tests/fake_sdk/sitecustomize.py
@@ -1,0 +1,82 @@
+"""Replace notion_client.Client with a fake, before the server imports it.
+
+Python runs sitecustomize at interpreter startup, ahead of any application import, so
+putting this directory on PYTHONPATH swaps the SDK for a stub without the server under
+test knowing. Every other layer, the MCP framework, the transport, the dispatch and the
+normalizers, is the real thing.
+
+The stub decides what to do from the id it is given, so one server process can serve
+every case the live tests need:
+
+    page-404 / user-404 / block-404  -> APIResponseError, object_not_found
+    page-401                         -> APIResponseError, unauthorized
+    page-403                         -> APIResponseError, restricted_resource
+    anything else                    -> a valid payload for that object kind
+"""
+
+import httpx
+import notion_client
+from notion_client.errors import APIResponseError, APIErrorCode
+
+# Message text as Notion actually sends it. The 404 wording is the one quoted in
+# issue #1664; the others are Notion's documented messages. They deliberately contain
+# none of the words the old string-matching classifier looked for.
+_FAILURES = {
+    "404": (404, APIErrorCode.ObjectNotFound,
+            "Could not find page with ID: 00000000-0000-0000-0000-000000000000."),
+    "401": (401, APIErrorCode.Unauthorized, "API token is invalid."),
+    "403": (403, APIErrorCode.RestrictedResource,
+            "Insufficient permissions for this endpoint."),
+}
+
+
+def _maybe_fail(object_id: str) -> None:
+    for suffix, (status, code, message) in _FAILURES.items():
+        if str(object_id).endswith(suffix):
+            request = httpx.Request("GET", f"https://api.notion.com/v1/{object_id}")
+            response = httpx.Response(status_code=status, text=message, request=request)
+            raise APIResponseError(response, message, code)
+
+
+class _Pages:
+    def retrieve(self, page_id, **kwargs):
+        _maybe_fail(page_id)
+        return {
+            "object": "page", "id": page_id,
+            "created_time": "2026-01-01T00:00:00.000Z",
+            "last_edited_time": "2026-01-02T00:00:00.000Z",
+            "created_by": {"object": "user", "id": "user-1"},
+            "archived": False,
+            "properties": {"Name": {"type": "title", "title": []}},
+            "url": "https://notion.so/page",
+        }
+
+
+class _Users:
+    def retrieve(self, user_id, **kwargs):
+        _maybe_fail(user_id)
+        return {"object": "user", "id": user_id, "type": "person",
+                "name": "Ada", "person": {"email": "ada@example.com"}}
+
+    def me(self, **kwargs):
+        return self.retrieve("user-me")
+
+
+class _Blocks:
+    def retrieve(self, block_id, **kwargs):
+        _maybe_fail(block_id)
+        return {"object": "block", "id": block_id, "type": "paragraph",
+                "has_children": False, "archived": False,
+                "paragraph": {"rich_text": []}}
+
+
+class FakeClient:
+    """Stands in for notion_client.Client. Only the surface the tests touch."""
+
+    def __init__(self, *args, **kwargs):
+        self.pages = _Pages()
+        self.users = _Users()
+        self.blocks = _Blocks()
+
+
+notion_client.Client = FakeClient

--- a/mcp_servers/notion/tests/test_error_handling.py
+++ b/mcp_servers/notion/tests/test_error_handling.py
@@ -1,0 +1,396 @@
+"""Unit tests for error handling in the Notion MCP server.
+
+A failed Notion call has to survive three steps to be useful to a client: it must be
+classified correctly, it must not be destroyed by response normalization, and it must
+reach the client flagged as an error. Each step had a defect.
+
+1. Classification. handle_notion_error searched str(error) for "Unauthorized", "Not
+   found" and "Forbidden". Notion sends "API token is invalid.", "Could not find page
+   with ID: ..." and "Insufficient permissions for this endpoint.", so none of the
+   three branches could match and every failure became a generic api_error. The SDK
+   supplies APIResponseError.code and .status, which is what it now reads.
+
+2. Normalization. The dispatch layer guarded on isinstance(result, dict), and an error
+   envelope is a dict, so it went into a normalizer built from mapping rules. Page,
+   database, comment and list lost every field and returned {}. Block, user and
+   property item copied the envelope's "type" into a payload field, returning
+   plausible-looking objects such as {"userType": "not_found_error"}.
+
+3. Reporting. CallToolResult.isError is set only for a handler that raises, and every
+   branch caught its exceptions and returned the message as content, so failures
+   arrived as successful calls.
+
+These tests cover the three in isolation. The end-to-end behaviour, through a real
+server process and the real MCP transport, is in test_live_end_to_end.py.
+"""
+
+import httpx
+import pytest
+from notion_client.errors import APIErrorCode, APIResponseError, RequestTimeoutError
+
+
+def _api_error(status: int, code: APIErrorCode, message: str) -> APIResponseError:
+    """Build the exception the Notion SDK would raise for a given failure."""
+    request = httpx.Request("GET", "https://api.notion.com/v1/pages/x")
+    return APIResponseError(httpx.Response(status_code=status, text=message,
+                                           request=request), message, code)
+
+
+# Notion's real message text. None of it contains the words the old classifier looked
+# for, which is why all three of its branches were unreachable. The 404 wording is the
+# one quoted in issue #1664.
+SDK_FAILURES = [
+    (404, APIErrorCode.ObjectNotFound, "Could not find page with ID: 0000.",
+     "not_found_error"),
+    (401, APIErrorCode.Unauthorized, "API token is invalid.",
+     "authentication_error"),
+    (403, APIErrorCode.RestrictedResource, "Insufficient permissions for this endpoint.",
+     "permission_error"),
+    (429, APIErrorCode.RateLimited, "You have been rate limited.", "api_error"),
+    (400, APIErrorCode.ValidationError, "body failed validation.", "api_error"),
+    (409, APIErrorCode.ConflictError, "Conflict occurred while saving.", "api_error"),
+    (503, APIErrorCode.ServiceUnavailable, "Notion is unavailable.", "api_error"),
+]
+
+ERROR_ENVELOPES = [
+    {"error": "Authentication failed. Please check your Notion API key.",
+     "type": "authentication_error"},
+    {"error": "The requested resource was not found. Check the ID and permissions.",
+     "type": "not_found_error"},
+    {"error": "Access denied. The integration may not have permission to access this resource.",
+     "type": "permission_error"},
+    {"error": "Notion API error: boom", "type": "api_error"},
+]
+
+NORMALIZER_NAMES = ["page", "database", "block", "user", "comment",
+                    "property_item", "list"]
+
+
+@pytest.fixture
+def page():
+    """A minimal but realistic page payload."""
+    return {
+        "object": "page", "id": "1a2b3c4d-0000-0000-0000-000000000000",
+        "created_time": "2026-01-01T00:00:00.000Z",
+        "last_edited_time": "2026-01-02T00:00:00.000Z",
+        "created_by": {"object": "user", "id": "user-1"},
+        "archived": False,
+        "properties": {"Name": {"type": "title", "title": []}},
+        "url": "https://notion.so/page",
+    }
+
+
+@pytest.fixture
+def block():
+    """A paragraph block. Its "type" collides with the envelope's "type"."""
+    return {"object": "block", "id": "block-1", "type": "paragraph",
+            "has_children": False, "archived": False, "paragraph": {"rich_text": []}}
+
+
+@pytest.fixture
+def user():
+    """A person user. Same collision on "type"."""
+    return {"object": "user", "id": "user-1", "type": "person", "name": "Ada",
+            "person": {"email": "ada@example.com"}}
+
+
+@pytest.fixture
+def list_response():
+    """A paginated list of pages."""
+    return {"object": "list",
+            "results": [{"object": "page", "id": "page-1"},
+                        {"object": "page", "id": "page-2"}],
+            "next_cursor": None, "has_more": False}
+
+
+def _normalizers():
+    """Resolve NORMALIZER_NAMES to the callables the dispatch layer uses."""
+    from functools import partial
+    import server
+    return {
+        "page": server.normalize_page,
+        "database": server.normalize_database,
+        "block": server.normalize_block,
+        "user": server.normalize_user,
+        "comment": server.normalize_comment,
+        "property_item": server.normalize_property_item,
+        "list": partial(server.normalize_list_response,
+                        item_normalizer=server.normalize_page),
+    }
+
+
+# --------------------------------------------------------------------------
+# 1. Classification
+# --------------------------------------------------------------------------
+
+class TestErrorClassification:
+    """handle_notion_error must read the SDK's structured fields, not the message."""
+
+    @pytest.mark.parametrize("status,code,message,expected", SDK_FAILURES,
+                             ids=[c.value for _, c, _, _ in SDK_FAILURES])
+    def test_classifies_from_the_sdk_error_code(self, status, code, message, expected):
+        """Every documented Notion error code lands in the right category."""
+        from tools.base import handle_notion_error
+        assert handle_notion_error(_api_error(status, code, message))["type"] == expected
+
+    @pytest.mark.parametrize("status,code,message,expected", SDK_FAILURES,
+                             ids=[c.value for _, c, _, _ in SDK_FAILURES])
+    def test_carries_vendor_code_status_and_message(self, status, code, message, expected):
+        """The precise Notion detail is preserved rather than replaced by prose.
+
+        The old envelope discarded which page was missing. "details" keeps it.
+        """
+        from tools.base import handle_notion_error
+        envelope = handle_notion_error(_api_error(status, code, message))
+        assert envelope["code"] == code.value
+        assert envelope["status"] == status
+        assert envelope["details"] == message
+
+    def test_message_text_alone_does_not_drive_classification(self):
+        """An exception whose text says "Not found" but carries no code is generic.
+
+        This is the inverse of the old bug and guards against reintroducing string
+        matching: prose must not be able to promote an error into a category.
+        """
+        from tools.base import handle_notion_error
+        assert handle_notion_error(Exception("Not found"))["type"] == "api_error"
+
+    def test_non_sdk_exception_still_produces_an_envelope(self):
+        """A plain exception is still reported, without code or status."""
+        from tools.base import handle_notion_error
+        envelope = handle_notion_error(ValueError("something odd"))
+        assert envelope["type"] == "api_error"
+        assert "something odd" in envelope["error"]
+        assert "code" not in envelope
+        assert "status" not in envelope
+
+    def test_timeout_is_reported_as_a_generic_error(self):
+        """RequestTimeoutError has a code attribute that is a plain string, not an
+        APIErrorCode, so it must not crash the lookup or be miscategorised."""
+        from tools.base import handle_notion_error
+        envelope = handle_notion_error(RequestTimeoutError())
+        assert envelope["type"] == "api_error"
+        assert envelope["code"] == "notionhq_client_request_timeout"
+
+
+# --------------------------------------------------------------------------
+# 2. The predicate that separates envelopes from payloads
+# --------------------------------------------------------------------------
+
+class TestIsErrorEnvelope:
+    """The single definition of the envelope shape."""
+
+    @pytest.mark.parametrize("envelope", ERROR_ENVELOPES,
+                             ids=[e["type"] for e in ERROR_ENVELOPES])
+    def test_accepts_every_category(self, envelope):
+        """Each of the four categories is recognised."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope(envelope) is True
+
+    def test_accepts_what_the_producer_emits(self):
+        """The predicate and the producer must agree on the real article."""
+        from tools.base import handle_notion_error, is_error_envelope
+        envelope = handle_notion_error(
+            _api_error(404, APIErrorCode.ObjectNotFound, "Could not find page."))
+        assert is_error_envelope(envelope) is True
+
+    def test_rejects_payload_whose_property_is_named_error(self, page):
+        """Notion property names are arbitrary, so "error" is a legal one.
+
+        This is the false positive a looser predicate would hit.
+        """
+        from tools.base import is_error_envelope
+        page["properties"]["error"] = {"type": "rich_text", "rich_text": []}
+        page["error"] = "a page can legitimately carry this key"
+        assert is_error_envelope(page) is False
+
+    def test_rejects_object_whose_type_is_a_notion_type(self, block):
+        """A block's type is "paragraph", never an error category."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope(block) is False
+
+    def test_rejects_error_key_with_unknown_type(self):
+        """A message with a type outside the vocabulary is not an envelope."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope({"error": "boom", "type": "teapot_error"}) is False
+
+    def test_rejects_missing_type(self):
+        """An error message alone is not enough."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope({"error": "boom"}) is False
+
+    def test_rejects_missing_error(self):
+        """A recognised type alone is not enough."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope({"type": "api_error"}) is False
+
+    def test_rejects_non_string_error(self):
+        """A property holding a dict under "error" cannot masquerade."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope({"error": {"nested": 1}, "type": "api_error"}) is False
+
+    @pytest.mark.parametrize("value", [None, [], "", 0, 3.5, True, set()],
+                             ids=["none", "list", "str", "int", "float", "bool", "set"])
+    def test_rejects_non_dict(self, value):
+        """Anything that is not a dict is not an envelope."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope(value) is False
+
+    def test_rejects_empty_dict(self):
+        """An empty dict is the symptom of the old bug, not an envelope."""
+        from tools.base import is_error_envelope
+        assert is_error_envelope({}) is False
+
+
+class TestProducerPredicateContract:
+    """The two must not drift apart."""
+
+    @pytest.mark.parametrize("status,code,message,expected", SDK_FAILURES,
+                             ids=[c.value for _, c, _, _ in SDK_FAILURES])
+    def test_every_produced_envelope_is_recognised(self, status, code, message, expected):
+        """A new category added to the producer without ERROR_TYPES fails here."""
+        from tools.base import handle_notion_error, is_error_envelope
+        assert is_error_envelope(handle_notion_error(_api_error(status, code, message)))
+
+    def test_error_types_has_no_unreachable_entries(self):
+        """A category left in ERROR_TYPES after its mapping is deleted fails here."""
+        from tools.base import handle_notion_error, ERROR_TYPES
+        produced = {handle_notion_error(_api_error(s, c, m))["type"]
+                    for s, c, m, _ in SDK_FAILURES}
+        produced.add(handle_notion_error(ValueError("x"))["type"])
+        assert produced == set(ERROR_TYPES)
+
+
+# --------------------------------------------------------------------------
+# 3. Failures escalate instead of being normalized away
+# --------------------------------------------------------------------------
+
+class TestFailuresEscalate:
+    """apply_normalizer turns an envelope into an exception the framework can flag."""
+
+    @pytest.mark.parametrize("kind", NORMALIZER_NAMES)
+    @pytest.mark.parametrize("envelope", ERROR_ENVELOPES,
+                             ids=[e["type"] for e in ERROR_ENVELOPES])
+    def test_every_normalizer_raises_on_an_envelope(self, kind, envelope):
+        """No normalizer may quietly consume a failure."""
+        from server import apply_normalizer, NotionToolError
+        with pytest.raises(NotionToolError):
+            apply_normalizer(dict(envelope), _normalizers()[kind])
+
+    def test_raised_error_carries_the_envelope(self):
+        """The structured detail is available to anything catching the exception."""
+        from server import apply_normalizer, NotionToolError, normalize_page
+        envelope = dict(ERROR_ENVELOPES[1])
+        with pytest.raises(NotionToolError) as excinfo:
+            apply_normalizer(envelope, normalize_page)
+        assert excinfo.value.envelope == envelope
+
+    def test_string_form_is_the_json_envelope(self):
+        """The framework builds error content from str(exception), so it has to be
+        the serialised envelope rather than a repr."""
+        import json
+        from server import apply_normalizer, NotionToolError, normalize_page
+        envelope = dict(ERROR_ENVELOPES[1])
+        with pytest.raises(NotionToolError) as excinfo:
+            apply_normalizer(envelope, normalize_page)
+        assert json.loads(str(excinfo.value)) == envelope
+
+
+# --------------------------------------------------------------------------
+# 4. The golden path must be untouched
+# --------------------------------------------------------------------------
+
+class TestGoldenPathStillNormalizes:
+    """Real payloads normalize exactly as before."""
+
+    def test_page_normalizes(self, page):
+        """A page maps onto its rule-defined field names."""
+        from server import apply_normalizer, normalize_page
+        out = apply_normalizer(page, normalize_page)
+        assert out["pageId"] == page["id"]
+        assert out["objectType"] == "page"
+        assert out["createdBy"] == "user-1"
+        assert out["urlPath"] == "https://notion.so/page"
+
+    def test_block_keeps_its_real_type(self, block):
+        """blockType still carries the Notion type the bug overwrote."""
+        from server import apply_normalizer, normalize_block
+        out = apply_normalizer(block, normalize_block)
+        assert out["blockId"] == "block-1"
+        assert out["blockType"] == "paragraph"
+        assert out["hasChildren"] is False
+
+    def test_user_keeps_its_real_type(self, user):
+        """Same collision, on the user object."""
+        from server import apply_normalizer, normalize_user
+        out = apply_normalizer(user, normalize_user)
+        assert out["userId"] == "user-1"
+        assert out["userType"] == "person"
+        assert out["personEmail"] == "ada@example.com"
+
+    def test_list_response_normalizes(self, list_response):
+        """Pagination and item mapping are unaffected."""
+        from functools import partial
+        from server import apply_normalizer, normalize_list_response, normalize_page
+        out = apply_normalizer(list_response,
+                               partial(normalize_list_response,
+                                       item_normalizer=normalize_page))
+        assert out["itemCount"] == 2
+        assert out["hasMoreResults"] is False
+        assert out["items"][0]["pageId"] == "page-1"
+
+    def test_page_with_property_named_error_still_normalizes(self, page):
+        """The false-positive case reaches the normalizer rather than raising."""
+        from server import apply_normalizer, normalize_page
+        page["properties"]["error"] = {"type": "rich_text", "rich_text": []}
+        out = apply_normalizer(page, normalize_page)
+        assert out["pageId"] == page["id"]
+        assert "error" in out["pageProperties"]
+
+
+class TestDegenerateInputs:
+    """Inputs that are neither a payload nor an envelope."""
+
+    @pytest.mark.parametrize("value", [None, [], "text", 0],
+                             ids=["none", "list", "str", "int"])
+    def test_non_dict_passes_through_unchanged(self, value):
+        """Preserves the behaviour of the isinstance guard this replaced."""
+        from server import apply_normalizer, normalize_page
+        assert apply_normalizer(value, normalize_page) == value
+
+    def test_empty_dict_is_normalized_not_raised(self):
+        """An empty dict is a payload as far as the boundary is concerned."""
+        from server import apply_normalizer, normalize_page
+        assert apply_normalizer({}, normalize_page) == {}
+
+
+# --------------------------------------------------------------------------
+# 5. What the guard is protecting against
+# --------------------------------------------------------------------------
+
+class TestRegressionDocumentsOldBehaviour:
+    """Pins what the normalizers do to an envelope when called directly.
+
+    These describe the defect, not desired behaviour. They exist so anyone who later
+    removes apply_normalizer can see exactly what breaks, and so a change to the
+    normalizers that alters the collision is noticed here rather than in production.
+    """
+
+    def test_mapping_normalizers_erase_the_envelope(self):
+        """page, database and comment drop every field and return {}."""
+        import server
+        envelope = dict(ERROR_ENVELOPES[1])
+        assert server.normalize_page(envelope) == {}
+        assert server.normalize_database(envelope) == {}
+        assert server.normalize_comment(envelope) == {}
+
+    def test_type_copying_normalizers_fabricate_a_field(self):
+        """block, user and property item launder the error into a payload field.
+
+        The more dangerous half: the caller receives a structurally valid object.
+        """
+        import server
+        envelope = dict(ERROR_ENVELOPES[1])
+        assert server.normalize_block(envelope) == {"blockType": "not_found_error"}
+        assert server.normalize_user(envelope) == {"userType": "not_found_error"}
+        assert server.normalize_property_item(envelope) == {"propertyType": "not_found_error"}

--- a/mcp_servers/notion/tests/test_live_end_to_end.py
+++ b/mcp_servers/notion/tests/test_live_end_to_end.py
@@ -1,0 +1,197 @@
+"""End-to-end tests against a running Notion MCP server.
+
+These start server.py as a real subprocess and talk to it over the MCP streamable HTTP
+transport with the real client, so the whole path is exercised: transport, session,
+the framework's CallToolRequest handler, the dispatch layer, handle_notion_error and
+the normalizers. Only the Notion SDK is replaced, by a sitecustomize on PYTHONPATH, so
+the tests need no credentials and make no outbound call.
+
+What they are here to prove, which the unit tests cannot:
+
+  1. a failed call arrives with isError set, so a client can detect it from the
+     protocol rather than by inspecting the body
+  2. the body is the structured envelope, correctly classified, rather than {} or a
+     fabricated field such as {"userType": "not_found_error"}
+  3. a successful call is unaffected
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SERVER_DIR = Path(__file__).resolve().parent.parent
+FAKE_SDK_DIR = Path(__file__).resolve().parent / "fake_sdk"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(port: int, proc: subprocess.Popen, timeout: float = 30.0) -> None:
+    """Block until the server accepts connections, failing loudly if it died."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            out, _ = proc.communicate(timeout=5)
+            raise RuntimeError(f"server exited early with {proc.returncode}:\n{out}")
+        with socket.socket() as s:
+            s.settimeout(0.5)
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.1)
+    raise TimeoutError(f"server did not listen on {port} within {timeout}s")
+
+
+@pytest.fixture(scope="module")
+def live_server():
+    """A real server process with the Notion SDK faked. Yields its /mcp URL."""
+    port = _free_port()
+    env = dict(os.environ)
+    # sitecustomize runs before the server's own imports, so Client is already fake.
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(FAKE_SDK_DIR)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+    env["NOTION_API_KEY"] = "test-token-not-a-real-key"
+    env["PYTHONUNBUFFERED"] = "1"
+
+    proc = subprocess.Popen(
+        [sys.executable, "server.py", "--port", str(port)],
+        cwd=str(SERVER_DIR), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    try:
+        _wait_for_port(port, proc)
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+async def _call(url: str, tool: str, arguments: dict):
+    """Open a session, call one tool, return the CallToolResult."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            return await session.call_tool(tool, arguments)
+
+
+def _body(result):
+    """The tool's JSON payload, as the client receives it."""
+    assert result.content, "no content returned"
+    return json.loads(result.content[0].text)
+
+
+@pytest.mark.asyncio
+class TestLiveFailuresAreReportedAsErrors:
+    """A failed Notion call must reach the client as a protocol-level error."""
+
+    async def test_not_found_sets_is_error(self, live_server):
+        """404 arrives with isError set rather than looking like a success."""
+        result = await _call(live_server, "notion_get_page", {"page_id": "page-404"})
+        assert result.isError is True
+
+    async def test_not_found_carries_the_classified_envelope(self, live_server):
+        """The body is the envelope, classified from the SDK's error code.
+
+        Before, this call returned {} with isError false, and the type would have been
+        "api_error" because the classifier searched the message for "Not found" while
+        Notion sends "Could not find page with ID: ...".
+        """
+        result = await _call(live_server, "notion_get_page", {"page_id": "page-404"})
+        body = _body(result)
+        assert body != {}
+        assert body["type"] == "not_found_error"
+        assert body["code"] == "object_not_found"
+        assert body["status"] == 404
+        assert "Could not find page with ID" in body["details"]
+
+    async def test_unauthorized_is_classified(self, live_server):
+        """401 becomes authentication_error, not the generic api_error."""
+        body = _body(await _call(live_server, "notion_get_page", {"page_id": "page-401"}))
+        assert body["type"] == "authentication_error"
+        assert body["code"] == "unauthorized"
+        assert body["status"] == 401
+
+    async def test_forbidden_is_classified(self, live_server):
+        """403 becomes permission_error."""
+        body = _body(await _call(live_server, "notion_get_page", {"page_id": "page-403"}))
+        assert body["type"] == "permission_error"
+        assert body["code"] == "restricted_resource"
+        assert body["status"] == 403
+
+    async def test_user_failure_is_not_laundered_into_a_payload_field(self, live_server):
+        """normalize_user used to turn the envelope into {"userType": "not_found_error"}.
+
+        That is the dangerous half of the bug: a structurally valid-looking object.
+        """
+        result = await _call(live_server, "notion_get_user", {"user_id": "user-404"})
+        body = _body(result)
+        assert result.isError is True
+        assert "userType" not in body
+        assert body["type"] == "not_found_error"
+
+    async def test_block_failure_is_not_laundered_into_a_payload_field(self, live_server):
+        """Same collision on normalize_block, which produced {"blockType": ...}."""
+        result = await _call(live_server, "notion_retrieve_block", {"block_id": "block-404"})
+        body = _body(result)
+        assert result.isError is True
+        assert "blockType" not in body
+        assert body["type"] == "not_found_error"
+
+
+@pytest.mark.asyncio
+class TestLiveSuccessPathUnaffected:
+    """The happy path must be untouched by any of the three changes."""
+
+    async def test_get_page_succeeds_and_normalizes(self, live_server):
+        """A real page still normalizes onto its rule-defined names, isError false."""
+        result = await _call(live_server, "notion_get_page", {"page_id": "page-ok"})
+        body = _body(result)
+        assert result.isError is False
+        assert body["pageId"] == "page-ok"
+        assert body["objectType"] == "page"
+        assert body["createdBy"] == "user-1"
+
+    async def test_get_user_keeps_its_real_type(self, live_server):
+        """userType must still carry "person", the field the bug overwrote."""
+        result = await _call(live_server, "notion_get_user", {"user_id": "user-ok"})
+        body = _body(result)
+        assert result.isError is False
+        assert body["userType"] == "person"
+        assert body["personEmail"] == "ada@example.com"
+
+    async def test_retrieve_block_keeps_its_real_type(self, live_server):
+        """blockType must still carry "paragraph"."""
+        result = await _call(live_server, "notion_retrieve_block", {"block_id": "block-ok"})
+        body = _body(result)
+        assert result.isError is False
+        assert body["blockType"] == "paragraph"
+
+
+@pytest.mark.asyncio
+class TestLiveServerContract:
+    """Basic protocol sanity, so a failure above is not mistaken for a broken harness."""
+
+    async def test_tools_are_listed(self, live_server):
+        """The server advertises its tools over the real transport."""
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        async with streamablehttp_client(live_server) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+        names = {t.name for t in tools.tools}
+        assert {"notion_get_page", "notion_get_user", "notion_retrieve_block"} <= names

--- a/mcp_servers/notion/tests/test_live_end_to_end.py
+++ b/mcp_servers/notion/tests/test_live_end_to_end.py
@@ -151,6 +151,20 @@ class TestLiveFailuresAreReportedAsErrors:
         assert body["type"] == "not_found_error"
 
 
+    async def test_internal_validation_error_also_sets_is_error(self, live_server):
+        """A failure raised inside a tool, before any API call, reports the same way.
+
+        create_page raises ValueError("Properties are required") and its own handler
+        converts it with handle_notion_error, so this exercises the api_error branch
+        and confirms the fix is not specific to SDK exceptions.
+        """
+        result = await _call(live_server, "notion_create_page", {"page": {}})
+        body = _body(result)
+        assert result.isError is True
+        assert body["type"] == "api_error"
+        assert "Properties are required" in body["details"]
+
+
 @pytest.mark.asyncio
 class TestLiveSuccessPathUnaffected:
     """The happy path must be untouched by any of the three changes."""

--- a/mcp_servers/notion/tools/__init__.py
+++ b/mcp_servers/notion/tools/__init__.py
@@ -1,4 +1,4 @@
-from .base import auth_token_context
+from .base import auth_token_context, is_error_envelope, ERROR_TYPES
 from .pages import create_page, get_page, update_page_properties, retrieve_page_property
 from .databases import query_database, get_database, create_database, update_database, create_database_item
 from .search import search_notion
@@ -8,6 +8,8 @@ from .blocks import retrieve_block, update_block, delete_block, get_block_childr
 
 __all__ = [
     'auth_token_context',
+    'is_error_envelope',
+    'ERROR_TYPES',
     'create_page',
     'get_page', 
     'update_page_properties',

--- a/mcp_servers/notion/tools/base.py
+++ b/mcp_servers/notion/tools/base.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional
 from contextvars import ContextVar
 from notion_client import Client
+from notion_client.errors import APIErrorCode
 
 # Context variable to store auth token for the current request
 auth_token_context: ContextVar[str] = ContextVar('auth_token', default="")
@@ -25,30 +26,89 @@ def get_notion_client() -> Client:
     return Client(auth=token)
 
 
+# Notion's SDK raises APIResponseError carrying a structured APIErrorCode and the HTTP
+# status, so classification can be exact. Only the three codes below map onto a
+# specific category; everything else stays "api_error", which is what the previous
+# behaviour already produced for them.
+#
+# This replaces a substring search over str(error) for "Unauthorized", "Not found" and
+# "Forbidden". Notion's messages read "API token is invalid.", "Could not find page
+# with ID: ..." and "Insufficient permissions for this endpoint.", so none of those
+# three branches could ever match and every failure was reported as a generic
+# api_error, including the 404 in issue #1664.
+_CODE_TO_TYPE = {
+    APIErrorCode.Unauthorized: "authentication_error",
+    APIErrorCode.RestrictedResource: "permission_error",
+    APIErrorCode.ObjectNotFound: "not_found_error",
+}
+
+# Guidance shown to the caller, keyed by category. Kept separate from the vendor's own
+# message, which is carried in "details" so the precise text ("Could not find page with
+# ID: X") is not thrown away.
+_GUIDANCE = {
+    "authentication_error": "Authentication failed. Please check your Notion API key.",
+    "permission_error": "Access denied. The integration may not have permission to access this resource.",
+    "not_found_error": "The requested resource was not found. Check the ID and permissions.",
+}
+
+
 def handle_notion_error(error: Exception) -> dict:
-    """Handle Notion API errors and return formatted error response."""
-    error_msg = str(error)
-    
-    if "Unauthorized" in error_msg:
-        return {
-            "error": "Authentication failed. Please check your Notion API key.",
-            "type": "authentication_error"
-        }
-    elif "Not found" in error_msg:
-        return {
-            "error": "The requested resource was not found. Check the ID and permissions.",
-            "type": "not_found_error"
-        }
-    elif "Forbidden" in error_msg:
-        return {
-            "error": "Access denied. The integration may not have permission to access this resource.",
-            "type": "permission_error"
-        }
-    else:
-        return {
-            "error": f"Notion API error: {error_msg}",
-            "type": "api_error"
-        }
+    """Handle Notion API errors and return a structured error envelope.
+
+    The envelope always carries "error" and "type". When the exception comes from the
+    Notion SDK it also carries "code" (the vendor's own error code), "status" (the HTTP
+    status) and "details" (the vendor's message), so a caller can act on the precise
+    failure rather than parse prose.
+    """
+    code = getattr(error, "code", None)
+    error_type = _CODE_TO_TYPE.get(code, "api_error")
+
+    envelope = {
+        "error": _GUIDANCE.get(error_type, f"Notion API error: {error}"),
+        "type": error_type,
+    }
+
+    if code is not None:
+        envelope["code"] = code.value if isinstance(code, APIErrorCode) else str(code)
+
+    status = getattr(error, "status", None)
+    if isinstance(status, int):
+        envelope["status"] = status
+
+    message = str(error)
+    if message and message != envelope["error"]:
+        envelope["details"] = message
+
+    return envelope
+
+
+
+# The four categories handle_notion_error can produce. The dispatch layer has to
+# recognise an envelope without re-deriving its shape, so the vocabulary lives here,
+# beside the only function that emits it.
+ERROR_TYPES = frozenset({
+    "authentication_error",
+    "not_found_error",
+    "permission_error",
+    "api_error",
+})
+
+
+def is_error_envelope(value: object) -> bool:
+    """Return True if value is an error envelope produced by handle_notion_error.
+
+    Notion payloads carry their own "type" key: a block's type is "paragraph", a
+    property's is "rich_text". So "type" alone cannot separate an envelope from a
+    real object. The test is deliberately narrow, requiring both keys, a string
+    message, and one of the four categories this module emits. A page whose
+    user-defined property happens to be named "error" is therefore not misread as
+    a failure.
+    """
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("error"), str)
+        and value.get("type") in ERROR_TYPES
+    )
 
 
 def validate_uuid(uuid_string: str) -> bool:


### PR DESCRIPTION
## Description

Fixing #1664 meant reading the whole error path, and the reported symptom turned out to
be the middle of four defects. Each one alone makes the others invisible, so this fixes
all four in three commits you can take separately.

```mermaid
flowchart TD
    A["notion_get_page(page_id)"] --> B{"Notion API"}
    B -->|"401 / 403 / 404"| C["1. handle_notion_error<br/>string match on str(error)<br/>never fires -> api_error"]
    C --> D["2. normalize_page / _user / _block<br/>envelope is a dict, so it is normalized<br/>-> {} or {userType: 'not_found_error'}"]
    D --> E["3. except Exception -> return 'Error: ...'<br/>handler returns, so isError stays false"]
    E --> F["4. framework sets isError=False"]
    F --> G["client sees a successful call"]
```

### 1. The classification never worked

`handle_notion_error` searched `str(error)` for `"Unauthorized"`, `"Not found"` and
`"Forbidden"`. Notion sends `"API token is invalid."`, `"Could not find page with ID:
..."` and `"Insufficient permissions for this endpoint."`. None of the three branches
could match, so every failure became a generic `api_error`, including the 404 this issue
reports. Running real `APIResponseError` objects through it:

| HTTP | Notion code | Was classified | Should be |
|---|---|---|---|
| 404 | `object_not_found` | `api_error` | `not_found_error` |
| 401 | `unauthorized` | `api_error` | `authentication_error` |
| 403 | `restricted_resource` | `api_error` | `permission_error` |

The SDK raises `APIResponseError` with an `APIErrorCode` and the HTTP status.
Classification now reads those. The envelope additionally carries `code`, `status` and
the vendor's own message under `details`, so a caller can act on the precise failure and
no longer loses which object was missing.

### 2. Normalization destroyed the envelope (the reported bug)

The guard was `isinstance(result, dict)`, and an error envelope is a dict, so it went
into a normalizer built from mapping rules. The issue reports `{}`, which is four of the
seven. The other three are worse, because the envelope's `type` key collides with the
`type` key every Notion object carries:

| Normalizer | Envelope became | |
|---|---|---|
| `normalize_page`, `_database`, `_comment`, `_list_response` | `{}` | error lost |
| `normalize_block` | `{"blockType": "not_found_error"}` | error laundered into a payload field |
| `normalize_user` | `{"userType": "not_found_error"}` | same |
| `normalize_property_item` | `{"propertyType": "not_found_error"}` | same |

The bottom three hand the client a structurally valid-looking object.

### 3. Failures were reported to MCP as successes

`CallToolResult.isError` is set only when the handler raises. Every branch caught its
exceptions and returned the message as content:

```python
except Exception as e:
    return [types.TextContent(type="text", text=f"Error: {str(e)}")]
```

`isError` appeared zero times in `server.py`, so a client had no protocol-level way to
know a call failed. This also affected unexpected exceptions, not just Notion errors.

### 4. The predicate has to be narrow

Notion property names are arbitrary strings, so a page can legitimately carry a property
called `error`, and every object has a `type`. Matching on either alone would misread
real payloads as failures, so `is_error_envelope` requires both keys, a string message,
and one of the categories `handle_notion_error` actually emits. There is a test for that
false positive.

### The shape of the fix

`is_error_envelope` and `ERROR_TYPES` live in `tools/base.py` beside the only function
that emits the shape, so the two cannot drift. `apply_normalizer` is the single boundary
across all 20 call sites: it detects the envelope and raises `NotionToolError` carrying
it as JSON, so the framework flags the response while the structured detail survives.
The per-branch handlers re-raise instead of swallowing. `google_docs` in this repository
already raises for the same reason.

### Scope: I checked every server the issue suspected

The issue expects this to reproduce across the other providers. I read each one rather
than assume, and Notion is the only affected server. Three of the others already do what
this PR adds.

| Server | Error strategy | Reaches a normalizer? | Affected |
|---|---|---|---|
| `notion` | returns an error dict | yes, the guard checks type only | **yes** |
| `outlook` | returns an error dict | no: `isinstance(result, dict) and 'error' not in result and 'id' in result` | no |
| `onedrive` | returns an error dict | no: guard requires `"id" in result` | no |
| `linear` | errors carried in the payload | no: returns early when `'data'` is absent, and copies `errors` through | no |
| `mem0` | returns an error dict | yes, but its rules map `error`, `success` and `status` through deliberately | no |
| `google_calendar` | raises `RuntimeError` | never, normalization is inside the `try` | no |
| `google_docs` | raises `RuntimeError` | never, same shape | no |

## Related issue

Fixes #1664

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Worth flagging: failing calls now arrive with `isError=true` instead of `false`. That is
what the MCP spec asks for and what `google_docs` already does, but it is a visible
change for any client that was inspecting the body instead. Happy to split that commit
out if you would rather take it separately.

## How has this been tested?

96 tests. No credentials, no Notion account, no outbound network call.

```
$ pip install -r requirements-test.txt
$ pytest tests/ -q
96 passed
```

**86 unit tests** covering classification against real `APIResponseError` objects for
every documented Notion error code, the predicate including the false positive above,
escalation through all seven normalizers, the golden path asserting `blockType` and
`userType` still carry the real Notion type, degenerate inputs, and a regression class
pinning the old corrupting behaviour so anyone removing the guard sees what breaks.

**10 end-to-end tests** start `server.py` as a real subprocess and drive it over the MCP
streamable HTTP transport with the real client, so transport, session, the framework's
`CallToolRequest` handler, dispatch and normalization are all exercised. A
`sitecustomize` on `PYTHONPATH` swaps only the Notion SDK for a stub, which is why they
need no account.

I checked the tests fail without each fix rather than assuming they would:

| Mutation | Result |
|---|---|
| classification reverted to matching `str(error)` | 10 failed, 86 passed |
| `apply_normalizer` stops detecting envelopes | 36 failed, 60 passed |
| dispatch swallows exceptions again | 6 failed, 90 passed |
| none | 96 passed |

The golden path survives every mutation, so the suite is specific rather than broadly
coupled. Verified from a clean clone of the branch.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
