### PR TITLE
fix(whatsapp): duplicate webhook handlers shadow the health check and expose an unauthenticated /webhook

### DIFF
--- a/mcp-clients/README-WhatsApp.md
+++ b/mcp-clients/README-WhatsApp.md
@@ -29,6 +29,9 @@ CALLBACK_URL=your_webhook_url
 PORT=8080
 ```
 
+`CALLBACK_URL` is the public root of this service, with no path appended. The webhook
+lives at `/`, and the health check at `/health`.
+
 ## WhatsApp API Setup
 
 1. Create a Meta Developer account at [developers.facebook.com](https://developers.facebook.com/)

--- a/mcp-clients/pyproject.toml
+++ b/mcp-clients/pyproject.toml
@@ -22,6 +22,12 @@ dependencies = [
     "uvloop>=0.17.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+]
+
 [tool.uv]
 package = true
 

--- a/mcp-clients/src/mcp_clients/whatsapp_bot.py
+++ b/mcp-clients/src/mcp_clients/whatsapp_bot.py
@@ -3,7 +3,7 @@ import logging
 import uvicorn
 import time
 from typing import Dict, Any, Optional, List
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI
 from pywa_async import WhatsApp, types
 from pywa_async.types import Message
 from dotenv import load_dotenv
@@ -48,6 +48,18 @@ wa = WhatsApp(
     app_secret=APP_SECRET,
     webhook_challenge_delay=20.0  # Increased delay for webhook challenge
 )
+
+# pywa owns the webhook routes. Passing `server=app` above registers them immediately,
+# at construction, ahead of anything declared later in this file. They sit on pywa's
+# default endpoint "/", which is where CALLBACK_URL points; README-WhatsApp.md asks for
+# the bare tunnel URL. Signature checking is already on, since validate_updates defaults
+# to True and app_secret is set, so pywa verifies X-Hub-Signature-256 on every update
+# and answers the hub.challenge handshake itself.
+#
+# Two things follow for anyone adding to this module. Do not declare a route on "/":
+# FastAPI keeps the first registration, so yours is shadowed and never runs. And do not
+# hand-write webhook handlers on some other path, because Meta pointed at them would
+# bypass the signature check that pywa is doing here.
 
 class WhatsAppBotContext(BotContext):
     """
@@ -459,44 +471,16 @@ async def handle_message(client: WhatsApp, message: Message):
         except:
             pass
 
-@app.get("/")
-async def root():
-    """Root endpoint for health check"""
+@app.get("/health")
+async def health():
+    """Report that the service is up.
+
+    This sits on /health rather than "/" because pywa claims "/" when the client above
+    is constructed. A health check declared on "/" is shadowed and never runs, and the
+    caller gets a 422 complaining about a missing hub.verify_token instead of a status,
+    which anything probing the service reads as unhealthy.
+    """
     return {"status": "ok", "service": "WhatsApp Bot"}
-
-# Add a webhook verification endpoint
-@app.get("/webhook")
-async def verify_webhook(request: Request):
-    """
-    Manually handle webhook verification
-    This helps to avoid issues with the automatic verification process
-    """
-    query_params = dict(request.query_params)
-    
-    # Extract verification parameters
-    mode = query_params.get("hub.mode")
-    token = query_params.get("hub.verify_token")
-    challenge = query_params.get("hub.challenge")
-    
-    # Verify parameters
-    if mode == "subscribe" and token == VERIFY_TOKEN:
-        logger.info("Webhook verified successfully!")
-        return Response(content=challenge, media_type="text/plain")
-    else:
-        logger.error(f"Webhook verification failed. Mode: {mode}, Token: {token}")
-        return Response(status_code=403)
-
-# Add a webhook endpoint for receiving messages
-@app.post("/webhook")
-async def webhook(request: Request):
-    """
-    Handle incoming webhook events
-    """
-    body = await request.json()
-    logger.debug(f"Received webhook: {body}")
-    
-    # Let the WhatsApp client process the webhook
-    return await wa.process_webhook(body)
 
 def main():
     """

--- a/mcp-clients/tests/conftest.py
+++ b/mcp-clients/tests/conftest.py
@@ -1,0 +1,138 @@
+"""Test setup for the WhatsApp bot.
+
+whatsapp_bot imports four project modules that pull in Supabase, the LLM clients and
+the MCP client stack. None of them takes part in webhook routing, so they are stubbed
+here to keep these tests on the thing under test: which handler serves each route, and
+what it does with a request. Everything else, FastAPI and pywa included, is real.
+"""
+
+import importlib
+import os
+import sys
+import types as pytypes
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest_plugins = ('pytest_asyncio',)
+
+# The real mcp_clients package must be importable so mcp_clients.whatsapp_bot resolves.
+# Only its heavyweight siblings are replaced.
+_SRC = str(Path(__file__).resolve().parent.parent / "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+def _stub(name: str, **attrs) -> None:
+    """Register a stub module under `name`, pre-empting the real import."""
+    mod = pytypes.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+
+
+def _install_project_stubs() -> None:
+    # Import the real package first. Stubbing a submodule only works once its parent
+    # exists in sys.modules, and shadowing mcp_clients itself would hide
+    # mcp_clients.whatsapp_bot, which is the module under test.
+    importlib.import_module("mcp_clients")
+
+    _stub("mcp_clients.base_bot",
+          BaseBot=MagicMock,
+          BotContext=type("BotContext", (), {"__init__": lambda self, *a, **k: None}))
+    _stub("mcp_clients.config", USE_PRODUCTION_DB=False)
+
+    llms = pytypes.ModuleType("mcp_clients.llms")
+    llms.__path__ = []
+    sys.modules.setdefault("mcp_clients.llms", llms)
+    _stub("mcp_clients.llms.base",
+          ChatMessage=MagicMock, Conversation=MagicMock, MessageRole=MagicMock,
+          TextContent=MagicMock, FileContent=MagicMock)
+    _stub("mcp_clients.mcp_client", MCPClient=MagicMock)
+
+
+_install_project_stubs()
+
+
+# Credentials the module reads at import time. They are fake, and nothing leaves the
+# process: pywa contacts Meta only when callback_url is set, and it is cleared below.
+#
+# These are applied at import of this file rather than inside a fixture. whatsapp_bot
+# reads the environment and constructs its pywa client at module scope, and pywa raises
+# if the verify token is missing, so the values have to be in place before any test
+# imports the module. Doing it in a fixture made the suite pass or fail depending on
+# which test pytest happened to run first.
+TEST_VERIFY_TOKEN = "test-verify-token-abc123"
+TEST_APP_SECRET = "test-app-secret-xyz789"
+
+os.environ.update({
+    "WHATSAPP_ACCESS_TOKEN": "test-access-token",
+    "WHATSAPP_APP_ID": "1234567890",
+    "WHATSAPP_APP_SECRET": TEST_APP_SECRET,
+    "WHATSAPP_PHONE_NUMBER_ID": "9876543210",
+    "WHATSAPP_VERIFY_TOKEN": TEST_VERIFY_TOKEN,
+})
+os.environ.pop("CALLBACK_URL", None)
+
+
+@pytest.fixture(scope="module")
+def bot_app():
+    """The real whatsapp_bot module's FastAPI app."""
+    from mcp_clients import whatsapp_bot
+    return whatsapp_bot.app
+
+
+@pytest.fixture(scope="module")
+def client(bot_app):
+    """A TestClient over the real app, exercising the real route table."""
+    from fastapi.testclient import TestClient
+    return TestClient(bot_app)
+
+
+@pytest.fixture
+def captured_messages():
+    """Swap the module's @wa.on_message callback for a recorder, then put it back.
+
+    pywa holds its own reference to the decorated function on the handler object, so
+    patching the module attribute alone changes nothing. Restoring afterwards is the
+    part that matters: a recorder left in place makes the suite order dependent, and a
+    test that only passes when it runs first is not worth much.
+
+    Yields the list the recorder appends to, as (text, wa_id) pairs.
+    """
+    from mcp_clients import whatsapp_bot
+
+    received = []
+
+    async def record(_client, message):
+        received.append((message.text, message.from_user.wa_id))
+
+    handlers = [h for hs in whatsapp_bot.wa._handlers.values() for h in hs
+                if hasattr(h, "_callback")]
+    assert handlers, "no registered pywa handler found to intercept"
+
+    originals = [(h, h._callback) for h in handlers]
+    for handler, _ in originals:
+        handler._callback = record
+    try:
+        yield received
+    finally:
+        for handler, callback in originals:
+            handler._callback = callback
+
+
+def wait_for(predicate, timeout: float = 2.0, interval: float = 0.02) -> bool:
+    """Poll until `predicate` holds or the timeout expires.
+
+    pywa dispatches handlers off the request, so a delivered message may land a moment
+    after the response returns. Polling with a generous ceiling beats a fixed sleep,
+    which either wastes time or goes flaky on a loaded machine.
+    """
+    import time as _time
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        if predicate():
+            return True
+        _time.sleep(interval)
+    return predicate()

--- a/mcp-clients/tests/test_webhook_routing.py
+++ b/mcp-clients/tests/test_webhook_routing.py
@@ -1,0 +1,219 @@
+"""Tests for the WhatsApp bot's webhook routing.
+
+The bot builds its pywa client with `server=app`, so pywa registers the webhook routes
+on the FastAPI app at construction time, before any route declared later in the module.
+pywa serves them at its default endpoint "/", which is where CALLBACK_URL points, and it
+verifies the X-Hub-Signature-256 header on every update. That path works.
+
+The module then hand-wrote a second pair of handlers at /webhook doing the same job
+badly, and declared a health check on "/" that pywa had already taken:
+
+  1. The health check never ran. GET / answered 422 for a missing hub.verify_token
+     parameter, so any container healthcheck or load balancer reads it as unhealthy.
+  2. The hand-written POST /webhook called wa.process_webhook, which is not a method of
+     pywa's WhatsApp class in any release, so it raised AttributeError.
+  3. It read request.json() and passed the parsed body on, discarding the raw bytes and
+     the signature header, so it authenticated nothing. Pointing Meta at /webhook would
+     pass verification and then silently deliver nothing.
+  4. Its GET counterpart compared the verify token with == (CWE-208, issue #1400).
+
+The fix deletes the duplicates and moves the health check to /health. These tests pin
+the behaviour of the surviving path end to end.
+"""
+
+import hashlib
+import hmac
+import json
+from .conftest import TEST_APP_SECRET, TEST_VERIFY_TOKEN, wait_for
+
+# An inbound text message shaped as Meta sends it.
+MESSAGE_UPDATE = {
+    "object": "whatsapp_business_account",
+    "entry": [{"id": "WABA", "changes": [{"field": "messages", "value": {
+        "messaging_product": "whatsapp",
+        "metadata": {"display_phone_number": "15550001111",
+                     "phone_number_id": "9876543210"},
+        # "user_id" is the business-scoped id Meta now sends alongside wa_id. pywa 4.x
+        # requires it when building the contact; 2.x ignores it. Including it keeps this
+        # fixture working on both.
+        "contacts": [{"profile": {"name": "Tester"}, "wa_id": "15551234567",
+                      "user_id": "BSUID15551234567"}],
+        "messages": [{"from": "15551234567", "id": "wamid.TEST",
+                      "timestamp": "1700000000", "type": "text",
+                      "text": {"body": "hello there"}}],
+    }}]}],
+}
+
+
+def _body(update=None) -> bytes:
+    """Serialise once: the signature covers these exact bytes, not a re-encoding."""
+    return json.dumps(update if update is not None else MESSAGE_UPDATE).encode()
+
+
+def _sign(body: bytes, secret: str = TEST_APP_SECRET) -> str:
+    """The X-Hub-Signature-256 header Meta sends."""
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _headers(body: bytes, secret: str = TEST_APP_SECRET) -> dict:
+    return {"Content-Type": "application/json", "X-Hub-Signature-256": _sign(body, secret)}
+
+
+class TestRouteOwnership:
+    """Who serves what, once the duplicates are gone."""
+
+    def test_pywa_owns_the_webhook_root(self, bot_app):
+        """pywa's handlers serve "/", which is where CALLBACK_URL points."""
+        served = {(r.path, m): r.endpoint.__name__
+                  for r in bot_app.routes
+                  for m in (getattr(r, "methods", None) or ())}
+        assert "pywa" in served[("/", "GET")]
+        assert "pywa" in served[("/", "POST")]
+
+    def test_root_has_exactly_one_handler_per_method(self, bot_app):
+        """A second registration would be shadowed and silently never run."""
+        for method in ("GET", "POST"):
+            n = sum(1 for r in bot_app.routes
+                    if r.path == "/" and method in (getattr(r, "methods", None) or ()))
+            assert n == 1, f"{n} handlers registered for {method} /"
+
+    def test_no_hand_written_webhook_routes_remain(self, bot_app):
+        """/webhook is gone rather than left serving an unauthenticated endpoint."""
+        assert not [r for r in bot_app.routes if r.path == "/webhook"]
+
+
+class TestHealthCheck:
+    """The health check was unreachable while pywa held "/"."""
+
+    def test_health_endpoint_responds(self, client):
+        """Reports status instead of 422 for a missing hub.verify_token."""
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok", "service": "WhatsApp Bot"}
+
+
+class TestVerificationChallenge:
+    """GET /, the handshake Meta performs when registering the webhook."""
+
+    def test_correct_token_returns_the_challenge(self, client):
+        r = client.get("/", params={"hub.mode": "subscribe",
+                                    "hub.verify_token": TEST_VERIFY_TOKEN,
+                                    "hub.challenge": "1158201444"})
+        assert r.status_code == 200
+        assert r.text == "1158201444"
+
+    def test_wrong_token_does_not_return_the_challenge(self, client):
+        r = client.get("/", params={"hub.mode": "subscribe",
+                                    "hub.verify_token": "wrong-token",
+                                    "hub.challenge": "1158201444"})
+        assert r.status_code == 403
+        assert "1158201444" not in r.text
+
+    def test_missing_token_does_not_return_the_challenge(self, client):
+        r = client.get("/", params={"hub.mode": "subscribe",
+                                    "hub.challenge": "1158201444"})
+        assert r.status_code in (403, 422)
+        assert "1158201444" not in r.text
+
+
+class TestSignatureEnforcement:
+    """Updates that cannot be attributed to Meta must not be processed.
+
+    These assert that a forged update is refused, not which status code carries the
+    refusal: pywa answers 401 for both missing and invalid signatures in the 2.x line
+    and separates 401 from 403 in 4.x.
+    """
+
+    @staticmethod
+    def _assert_refused(response) -> None:
+        assert 400 <= response.status_code < 500, (
+            f"forged update was not refused: {response.status_code} {response.text}")
+
+    def test_unsigned_update_is_refused(self, client):
+        r = client.post("/", content=_body(),
+                        headers={"Content-Type": "application/json"})
+        self._assert_refused(r)
+
+    def test_wrong_secret_is_refused(self, client):
+        body = _body()
+        r = client.post("/", content=body, headers=_headers(body, "not-the-app-secret"))
+        self._assert_refused(r)
+
+    def test_signature_over_other_bytes_is_refused(self, client):
+        """Guards a fix that verifies a re-serialised body rather than what was sent."""
+        r = client.post("/", content=_body(), headers={
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": _sign(b'{"object":"other","entry":[]}')})
+        self._assert_refused(r)
+
+    def test_replayed_signature_on_tampered_body_is_refused(self, client):
+        original = _body()
+        tampered = _body({**MESSAGE_UPDATE, "object": "tampered"})
+        r = client.post("/", content=tampered, headers={
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": _sign(original)})
+        self._assert_refused(r)
+
+
+class TestMessageIsActuallyDelivered:
+    """The point of the endpoint: a genuine message must reach the bot's handler.
+
+    A 200 alone proves nothing here. pywa answers 200 for a well-signed update it does
+    not recognise, so a status assertion would pass even if the message were dropped on
+    the floor. These assert the module's own @wa.on_message callback ran and saw the
+    message. The captured_messages fixture restores the real callback afterwards, so the
+    tests do not depend on running in any particular order.
+    """
+
+    def test_signed_message_reaches_the_handler(self, client, captured_messages):
+        """A properly signed inbound text message is delivered, intact."""
+        body = _body()
+        response = client.post("/", content=body, headers=_headers(body))
+        assert response.status_code == 200
+
+        assert wait_for(lambda: len(captured_messages) == 1), (
+            f"message was not delivered to the handler: {captured_messages}")
+        assert captured_messages == [("hello there", "15551234567")]
+
+    def test_unsigned_message_never_reaches_the_handler(self, client, captured_messages):
+        """The security property stated as an effect, not as a status code.
+
+        Refusing with a 4xx is only half of it. What matters is that the payload never
+        reaches application code.
+        """
+        client.post("/", content=_body(),
+                    headers={"Content-Type": "application/json"})
+        assert not wait_for(lambda: bool(captured_messages), timeout=0.5)
+        assert captured_messages == [], "a forged update was dispatched to the handler"
+
+    def test_wrongly_signed_message_never_reaches_the_handler(self, client,
+                                                             captured_messages):
+        """Same, for a signature computed with the wrong secret."""
+        body = _body()
+        client.post("/", content=body, headers=_headers(body, "not-the-app-secret"))
+        assert not wait_for(lambda: bool(captured_messages), timeout=0.5)
+        assert captured_messages == []
+
+
+class TestModuleNoLongerCarriesTheDuplicates:
+    """The duplicates are removed, not merely bypassed."""
+
+    def test_no_manual_webhook_decorators(self):
+        import inspect
+        from mcp_clients import whatsapp_bot
+        src = inspect.getsource(whatsapp_bot)
+        assert '@app.get("/webhook")' not in src
+        assert '@app.post("/webhook")' not in src
+
+    def test_no_call_to_a_method_pywa_does_not_have(self):
+        """wa.process_webhook is absent from every pywa release."""
+        import inspect
+        from mcp_clients import whatsapp_bot
+        assert "process_webhook" not in inspect.getsource(whatsapp_bot)
+
+    def test_client_is_configured_to_validate_updates(self):
+        from mcp_clients import whatsapp_bot
+        wa = whatsapp_bot.wa
+        assert wa._app_secret == TEST_APP_SECRET
+        assert wa._validate_updates is True
+        assert wa._webhook_endpoint == "/"


### PR DESCRIPTION
## Description

Fixing #1400 meant reading the whole webhook path. The `==` comparison is real, but it
sits in a hand-written duplicate of handlers pywa already provides, and the duplicate
brings worse problems than the comparison does.

## Before you merge: four things to decide

Putting these first so they are not buried. None is a blocker, but each is a judgement
I made that you may want made differently.

1. **`/webhook` now returns 404.** A deployment whose `CALLBACK_URL` includes that path
   will fail Meta's verification instead of passing it and delivering nothing. Failing
   loudly is better than the current silent no-op, but it is a visible change for that
   configuration. Say the word and I will keep a compatibility route that delegates to
   pywa's validated handlers.
2. **The health check moved from `/` to `/health`.** Anything probing `/` needs
   repointing, though `/` currently answers 422, so nothing can be usefully probing it
   today. This is a second bug found in the same block rather than part of #1400, and I
   am happy to split it into its own PR.
3. **#1400's weakness moves upstream, it does not vanish.** pywa's own
   `webhook_challenge_handler` also compares the verify token with `==`. I did not keep
   a duplicate handler alive purely to wrap one comparison. I can raise it with pywa, or
   add a constant-time check here if you would rather own it.
4. **`pywa>=0.7.0` is unbounded**, across four major versions, and is what let this code
   drift onto an API that does not exist. Left alone as belonging with #1660.

One more thing worth knowing, which this PR does not change: if `WHATSAPP_APP_SECRET` is
unset, pywa disables signature validation and the webhook accepts any POST, including
one carrying a fabricated `X-Hub-Signature-256`. I confirmed that behaviour. pywa already
logs `No app_secret provided. Signature validation will be disabled` at WARNING, so I did
not add a second warning saying the same thing.

## What is wrong

The bot builds its pywa client with `server=app`:

```python
wa = WhatsApp(phone_id=..., server=app, callback_url=CALLBACK_URL, app_secret=APP_SECRET, ...)
```

That registers pywa's webhook routes on the app **at that point**, before any route
declared later in the module. pywa serves them at its default `"/"`, which is where
`CALLBACK_URL` points, and it verifies `X-Hub-Signature-256` on every update. **That path
works, and this PR leaves it exactly where it is.**

The module then hand-wrote a second pair of handlers at `/webhook`, and declared a health
check on `"/"` that pywa had already taken.

| Route | Served by | State before |
|---|---|---|
| `GET /` | pywa | correct |
| `POST /` | pywa | correct, signature-validated, messages delivered |
| `GET /` health check, line 462 | never runs | **shadowed**, so `GET /` answers 422 |
| `GET /webhook` | hand-written | live, `==` comparison (#1400) |
| `POST /webhook` | hand-written | live, authenticates nothing, `AttributeError` |

**`wa.process_webhook` does not exist.** Not a method of pywa's `WhatsApp` class, and
absent from pywa's source in 1.26.0, 2.9.0, 2.11.0 and 4.4.0. `uv.lock` pins **pywa
2.9.0** and `Dockerfile.whatsapp` installs with `uv sync --frozen`, so that is the
shipped image:

```
pywa 2.9.0
process_webhook: AttributeError -> 'WhatsApp' object has no attribute 'process_webhook'
```

**That handler authenticates nothing.** It reads `request.json()` and passes the parsed
body on, discarding the raw bytes the HMAC covers and the signature header.

## The fix

Delete the duplicates, move the health check to `/health`, and state in
README-WhatsApp.md that `CALLBACK_URL` is the service root with no path appended, since
that ambiguity is what allowed this. **12 lines added, 34 removed**, no new
configuration, and the module goes from three declared routes to one.

## Related issue

Fixes #1400

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

17 tests against the real FastAPI app with real pywa. No credentials, and the suite makes
**zero** requests to graph.facebook.com. Only the four project modules `whatsapp_bot`
imports for the LLM and MCP stacks are stubbed; none takes part in routing.

```
$ pip install -e ".[dev]"
$ pytest tests/ -q
17 passed
```

**Three tests assert delivery, not status.** A 200 proves little, since pywa answers 200
for a well-signed update it does not recognise. Those post a real inbound text message
and assert the module's own `@wa.on_message` callback ran and saw it, and that unsigned
and wrongly signed updates never reach it.

| Verification | Result |
|---|---|
| Against the pre-fix module | **6 of 17 fail**: route ownership, health check, module hygiene |
| Signature tests against pre-fix | pass, because `"/"` was already validating. Recorded rather than claimed as a fix |
| Message dispatch disabled | the three delivery tests error at fixture setup, so they are not vacuous |
| 40 randomised orderings, and each class alone | 0 failures |
| pywa 2.9.0 (locked) and 4.4.0 (latest) | 17 passed on both |
| Clean clone of the branch | 17 passed on both versions |

### Against a real server process

Beyond the suite, I ran `whatsapp_bot` as an actual process and drove it over HTTP:

| Request | Result |
|---|---|
| `GET /health` | 200 `{"status":"ok","service":"WhatsApp Bot"}` |
| `GET /` correct verify token | 200, returns the challenge |
| `GET /` wrong verify token | 403 |
| `POST /` unsigned | 422 |
| `POST /` wrong secret | 401 |
| `POST /` correctly signed | 200, log shows `Received message: live probe from 15551234567` |
| `GET` and `POST /webhook` | 404 |

The handler then failed at `indicate_typing` with `ExpiredAccessToken`, the expected
outcome of a fake token, which confirms the message reached application code.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
